### PR TITLE
Log: replace asl_log with NSLog

### DIFF
--- a/FBControlCore/Utility/FBControlCoreLogger.m
+++ b/FBControlCore/Utility/FBControlCoreLogger.m
@@ -79,7 +79,11 @@
     if (self.fileDescriptor >= STDIN_FILENO) {
       int result = asl_add_output_file(client, self.fileDescriptor, ASL_MSG_FMT_STD, ASL_TIME_FMT_LCL, filterLimit, ASL_ENCODE_SAFE);
       if (result != 0) {
+        NSLog(@"Failed to add File Descriptor %@ to client with error %@",
+              @(self.fileDescriptor), @(result));
+        /*
         asl_log(client, NULL, ASL_LEVEL_ERR, "Failed to add File Descriptor %d to client with error %d", self.fileDescriptor, result);
+        */
       }
     }
 
@@ -120,7 +124,8 @@
 - (id<FBControlCoreLogger>)log:(NSString *)string
 {
   string = self.prefix ? [self.prefix stringByAppendingFormat:@" %@", string] : string;
-  asl_log(self.client, NULL, self.currentLevel, string.UTF8String, NULL);
+  NSLog(@"%@", string);
+  //asl_log(self.client, NULL, self.currentLevel, string.UTF8String, NULL);
   return self;
 }
 


### PR DESCRIPTION
### Motivation

Resolves **Turn off FBControlCore ASL** [calabash/iOSDeviceManager #8](https://github.com/calabash/iOSDeviceManager/issues/8)

ASL resists redirection and spams the Terminal with unwanted messages.

I decided to replace `asl_log` with `NSLog` instead of spending time implementing a new logger.
