### PR TITLE
Bootstrap: disable logging for missing XCTRequest

### DIFF
--- a/XCTestBootstrap/TestManager/FBTestManagerAPIMediator.m
+++ b/XCTestBootstrap/TestManager/FBTestManagerAPIMediator.m
@@ -301,12 +301,12 @@ const NSInteger FBProtocolMinimumVersion = 0x8;
 
 - (id)_XCT_testCase:(NSString *)arg1 method:(NSString *)arg2 didFinishActivity:(XCActivityRecord *)arg3
 {
-  return [self handleUnimplementedXCTRequest:_cmd];
+  return nil;
 }
 
 - (id)_XCT_testCase:(NSString *)arg1 method:(NSString *)arg2 willStartActivity:(XCActivityRecord *)arg3
 {
-  return [self handleUnimplementedXCTRequest:_cmd];
+  return nil;
 }
 
 - (id)_XCT_recordedOrientationChange:(NSString *)arg1

--- a/XCTestBootstrap/TestManager/FBXCTestManagerLoggingForwarder.m
+++ b/XCTestBootstrap/TestManager/FBXCTestManagerLoggingForwarder.m
@@ -56,7 +56,11 @@
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
   if ([self.interface respondsToSelector:invocation.selector]) {
-    [self.logger.debug log:NSStringFromSelector(invocation.selector)];
+
+    if ([FBControlCoreGlobalConfiguration debugLoggingEnabled]) {
+      [self.logger.debug log:NSStringFromSelector(invocation.selector)];
+    }
+
     [invocation invokeWithTarget:self.interface];
   } else {
     [super forwardInvocation:invocation];


### PR DESCRIPTION
**REBASED** Thu Sep 1 19:29 CET
### Motivation

With the Springboard alert handler in the RunLoop the log fills up instantly with these message.  The handler logs and returns nil so I think it is fine to turn off the logging.

Pages and pages of this:

```
2016-09-01 00:07:12.638 iOSDeviceManager[55759:536058] *** Assertion failure in -[FBTestManagerAPIMediator handleUnimplementedXCTRequest:], /Users/moody/git/calabash/FBSimulatorControl/XCTestBootstrap/TestManager/FBTestManagerAPIMediator.m:386
2016-09-01 00:07:12.639 iOSDeviceManager[55759:536058] _XCT_testCase:method:didFinishActivity:
2016-09-01 00:07:12.639 iOSDeviceManager[55759:536058] Received call for unhandled method (_XCT_testCase:method:didFinishActivity:). Probably you should have a look at _IDETestManagerAPIMediator in IDEFoundation.framework and implement it. Good luck!
2016-09-01 00:07:12.639 iOSDeviceManager[55759:536058] *** Assertion failure in -[FBTestManagerAPIMediator handleUnimplementedXCTRequest:], /Users/moody/git/calabash/FBSimulatorControl/XCTestBootstrap/TestManager/FBTestManagerAPIMediator.m:386
2016-09-01 00:07:12.736 iOSDeviceManager[55759:536058] _XCT_testCase:method:willStartActivity:
2016-09-01 00:07:12.736 iOSDeviceManager[55759:536058] Received call for unhandled method (_XCT_testCase:method:willStartActivity:). Probably you should have a look at _IDETestManagerAPIMediator in IDEFoundation.framework and implement it. Good luck!
2016-09-01 00:07:12.736 iOSDeviceManager[55759:536058] *** Assertion failure in -[FBTestManagerAPIMediator handleUnimplementedXCTRequest:], /Users/moody/git/calabash/FBSimulatorControl/XCTestBootstrap/TestManager/FBTestManagerAPIMediator.m:386
2016-09-01 00:07:12.848 iOSDeviceManager[55759:536058] _XCT_testCase:method:willStartActivity:
2016-09-01 00:07:12.848 iOSDeviceManager[55759:536058] Received call for unhandled method (_XCT_testCase:method:willStartActivity:). Probably you should have a look at _IDETestManagerAPIMediator in IDEFoundation.framework and implement it. Good luck!
```
