### PR TITLE
Bootstrap: log when a testCaseDidFailForTest

### DIFF
--- a/XCTestBootstrap/TestManager/FBTestManagerAPIMediator.m
+++ b/XCTestBootstrap/TestManager/FBTestManagerAPIMediator.m
@@ -262,6 +262,8 @@ const NSInteger FBProtocolMinimumVersion = 0x8;
 
 - (id)_XCT_testCaseDidFailForTestClass:(NSString *)testClass method:(NSString *)method withMessage:(NSString *)message file:(NSString *)file line:(NSNumber *)line
 {
+  NSLog(@"Test failed: %@", message);
+  NSLog(@"File: %@:%@", file, line);
   return nil;
 }
 


### PR DESCRIPTION
### Motivation

I am debugging failures and would like more information about why the Test Plan ended.
### Example

```
Test failed: UI Testing Failure - Application is not running, unable to get Accessibility data. Did you call -launch?
```
