### PR TITLE
rm duplicate reference

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -58,7 +58,6 @@
 		8969FC7C1DAC11FF002E5DE9 /* CalabashUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8969FC771DAC11FF002E5DE9 /* CalabashUtils.h */; };
 		8969FC7D1DAC11FF002E5DE9 /* CalabashUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8969FC781DAC11FF002E5DE9 /* CalabashUtils.m */; };
 		8969FC801DAC11FF002E5DE9 /* CalabashUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8969FC781DAC11FF002E5DE9 /* CalabashUtils.m */; };
-		8969FC811DAC11FF002E5DE9 /* CalabashUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8969FC781DAC11FF002E5DE9 /* CalabashUtils.m */; };
 		89AFD2DC1CF858D8003D365E /* FBDeviceControl.h in Headers */ = {isa = PBXBuildFile; fileRef = AAC8B22D1CEC51120034A865 /* FBDeviceControl.h */; };
 		89B188D51DA6A43300E171BE /* FBCodesignProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = AA58F88F1D959593006F8D81 /* FBCodesignProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA017F581BD7787300F45E9D /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
@@ -3064,7 +3063,6 @@
 				AAEE425B1D86939F0077D141 /* FBSimulatorScale.m in Sources */,
 				AA4242F21C529145008ABD80 /* FBFramebufferCompositeDelegate.m in Sources */,
 				AA95179A1C15F54600A89CAD /* FBDispatchSourceNotifier.m in Sources */,
-				8969FC811DAC11FF002E5DE9 /* CalabashUtils.m in Sources */,
 				AA9517681C15F54600A89CAD /* FBSimulatorInteraction+Applications.m in Sources */,
 				AA2F45C31D6ED47B00365A2C /* FBSimulatorServiceContext.m in Sources */,
 				AA9517781C15F54600A89CAD /* FBSimulatorDiagnostics.m in Sources */,


### PR DESCRIPTION
Should silence a warning in `iOSDeviceManager`
