### PR TITLE
CalabashUtils: remove unused log file method

### DIFF
--- a/Calabash/CalabashUtils.h
+++ b/Calabash/CalabashUtils.h
@@ -5,6 +5,4 @@
 + (void)doOnMain:(void(^)(void))someWork;
 + (id)doOnMainAndReturn:(id(^)(void))someResult;
 
-+ (NSString *)logfileLocation:(NSError **)err;
-
 @end

--- a/Calabash/CalabashUtils.m
+++ b/Calabash/CalabashUtils.m
@@ -23,29 +23,4 @@
     }
 }
 
-//Try to store logs at "${HOME}/.calabash/iOSDeviceManager/logs"
-+ (NSString *)logfileLocation:(NSError *__autoreleasing *)err {
-    NSString *errStr = nil;
-    NSString *logsDir = [[[NSHomeDirectory()
-                           stringByAppendingPathComponent:@".calabash"]
-                          stringByAppendingPathComponent:@"iOSDeviceManager"]
-                         stringByAppendingPathComponent:@"logs"];
-    
-    NSFileManager *fm = [NSFileManager defaultManager];
-    if (![fm fileExistsAtPath:logsDir]) {
-        NSError *e;
-        [fm createDirectoryAtPath:logsDir withIntermediateDirectories:YES attributes:nil error:&e];
-        if (e) {
-            errStr = [NSString stringWithFormat:@"Error creating logging dir at %@: %@", logsDir, e];
-        }
-    }
-    if (errStr) {
-        logsDir = nil;
-        *err = [NSError errorWithDomain:@"sh.calaba.iOSDeviceManager.LoggingError"
-                                   code:27753
-                               userInfo:@{NSLocalizedDescriptionKey: errStr}];
-    }
-    return logsDir;
-}
-
 @end


### PR DESCRIPTION
### Motivation

Should have been removed in **Build frameworks with CocoaLumberjack.framework** #14 