### PR TITLE
Xcode 8.3 - part 2: skip loading DVTFoundation.framework in Xcode 8.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ fbsimctl/cli-tests/supports_metal
 
 output/
 .clang-format
+
+## AppCode
+.idea

--- a/FBControlCore/FBControlCore.h
+++ b/FBControlCore/FBControlCore.h
@@ -62,6 +62,7 @@
 #import <FBControlCore/FBTaskBuilder.h>
 #import <FBControlCore/FBTerminationHandle.h>
 #import <FBControlCore/FBVideoRecordingCommands.h>
+#import <FBControlCore/FBDependentDylib.h>
 #import <FBControlCore/FBWeakFramework+ApplePrivateFrameworks.h>
 #import <FBControlCore/FBWeakFrameworkLoader.h>
 #import <FBControlCore/NSPredicate+FBControlCore.h>

--- a/FBControlCore/FBControlCore.h
+++ b/FBControlCore/FBControlCore.h
@@ -62,6 +62,7 @@
 #import <FBControlCore/FBTaskBuilder.h>
 #import <FBControlCore/FBTerminationHandle.h>
 #import <FBControlCore/FBVideoRecordingCommands.h>
+#import <FBControlCore/FBDependentDylib+ApplePrivateDylibs.h>
 #import <FBControlCore/FBDependentDylib.h>
 #import <FBControlCore/FBWeakFramework+ApplePrivateFrameworks.h>
 #import <FBControlCore/FBWeakFrameworkLoader.h>

--- a/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.h
+++ b/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <FBControlCore/FBDependentDylib.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Creates FBDependentDylib that represents private Apple dylibs that are
+ required by ControlCore.
+ */
+@interface FBDependentDylib (ApplePrivateDylibs)
+
+/**
+ Swift dylibs required by some versions of Xcode.
+ */
++ (NSArray<FBDependentDylib *> *)SwiftDylibs;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
+++ b/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBDependentDylib+ApplePrivateDylibs.h"
+#import "FBControlCoreGlobalConfiguration.h"
+
+@implementation FBDependentDylib (ApplePrivateDylibs)
+
++ (NSArray<FBDependentDylib *> *)SwiftDylibs
+{
+
+  // Starting in Xcode 8.3, IDEFoundation.framework requires Swift libraries to be loaded
+  // prior to loading the framework itself.
+  //
+  // You can inspect what libraries are loaded and in what order using:
+  //
+  // $ xcrun otool -l Xcode.app/Contents/Frameworks/IDEFoundation.framework
+  //
+  // The minimum macOS version for Xcode 8.3 is Sierra 10.12 so there is no need to
+  // branch on the macOS version.
+  //
+  // The order matters!  The first swift dylib loaded by IDEFoundation.framework is
+  // AppKit.  However, AppKit requires CoreImage and QuartzCore to be loaded first.
+
+  NSDecimalNumber *xcodeVersion = [FBControlCoreGlobalConfiguration xcodeVersionNumber];
+  NSDecimalNumber *xcode83 = [NSDecimalNumber decimalNumberWithString:@"8.3"];
+  BOOL atLeastXcode83 = [xcodeVersion compare:xcode83] != NSOrderedAscending;
+
+  if (atLeastXcode83) {
+    return @[
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreImage.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftQuartzCore.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftAppKit.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCore.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreData.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreGraphics.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDarwin.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDispatch.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftFoundation.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftIOKit.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftObjectiveC.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftXPC.dylib"]
+             ];
+  } else {
+    // No swift dylibs are required.
+    return @[];
+  }
+}
+
+@end

--- a/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
+++ b/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
@@ -34,18 +34,18 @@
 
   if (atLeastXcode83) {
     return @[
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCore.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDarwin.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftObjectiveC.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDispatch.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftIOKit.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreGraphics.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftFoundation.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftXPC.dylib"],
              [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreImage.dylib"],
              [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftQuartzCore.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftAppKit.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCore.dylib"],
              [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreData.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreGraphics.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDarwin.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDispatch.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftFoundation.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftIOKit.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftObjectiveC.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftXPC.dylib"]
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftAppKit.dylib"],
              ];
   } else {
     // No swift dylibs are required.

--- a/FBControlCore/Utility/FBDependentDylib.h
+++ b/FBControlCore/Utility/FBDependentDylib.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol FBControlCoreLogger;
+
+/**
+ Represents a dylib that FBControlCore is dependent on
+ */
+@interface FBDependentDylib : NSObject
+
+/**
+ Creates and returns FBDependentDylib with the given path.
+
+ @param relativePath a path relative to /path/to/Xcode.app/Contents
+ @return an FBDependentDylib instance
+ */
++ (instancetype)dependentWithRelativePath:(NSString *)relativePath;
+
+
+/**
+ Loads the framework using dlopen.
+
+ @param logger a logger for logging framework loading activities.
+ @param error an error out for any error that occurs.
+ @return YES if successful, NO otherwise.
+ */
+- (BOOL)loadWithLogger:(id<FBControlCoreLogger>)logger error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FBControlCore/Utility/FBDependentDylib.m
+++ b/FBControlCore/Utility/FBDependentDylib.m
@@ -46,11 +46,12 @@
 {
   NSURL *url = [NSURL fileURLWithPath:self.path];
   const char *cFileSystemRep = [url fileSystemRepresentation];
-  void *handle = dlopen(cFileSystemRep, RTLD_LOCAL|RTLD_LAZY);
+  void *handle = dlopen(cFileSystemRep, RTLD_NOW|RTLD_GLOBAL);
   [logger.debug logFormat:@"Attempting to load: %s", cFileSystemRep];
   if (!handle) {
     NSString *message = [NSString stringWithFormat:@"Could not load dylib %@ with dlopen: %s",
                          self.path, dlerror()];
+    [logger.debug logFormat:@"%@", message];
     return [FBControlCoreError failBoolWithErrorMessage:message
                                                errorOut:error];
   } else {

--- a/FBControlCore/Utility/FBDependentDylib.m
+++ b/FBControlCore/Utility/FBDependentDylib.m
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBDependentDylib.h"
+#import "FBControlCoreError.h"
+#import "FBControlCoreGlobalConfiguration.h"
+#import "FBControlCoreLogger.h"
+#import <dlfcn.h>
+
+@interface FBDependentDylib ()
+
+@property (nonatomic, copy, readonly) NSString *path;
+
+@end
+
+@implementation FBDependentDylib
+
+
+#pragma mark Initializers
+
++ (instancetype)dependentWithRelativePath:(NSString *)relativePath
+{
+  return [[FBDependentDylib alloc] initWithRelativePath:relativePath];
+}
+
+- (instancetype)initWithRelativePath:(NSString *)relativePath
+{
+  self = [super init];
+  if (self) {
+    NSString *developerDirectory = FBControlCoreGlobalConfiguration.developerDirectory;
+    NSString *joined = [developerDirectory stringByAppendingPathComponent:relativePath];
+    _path = [joined stringByStandardizingPath];
+  }
+  return self;
+}
+
+#pragma mark Public
+
+- (BOOL)loadWithLogger:(id<FBControlCoreLogger>)logger error:(NSError **)error
+{
+  NSURL *url = [NSURL fileURLWithPath:self.path];
+  const char *cFileSystemRep = [url fileSystemRepresentation];
+  void *handle = dlopen(cFileSystemRep, RTLD_LOCAL|RTLD_LAZY);
+  [logger.debug logFormat:@"Attempting to load: %s", cFileSystemRep];
+  if (!handle) {
+    NSString *message = [NSString stringWithFormat:@"Could not load dylib %@ with dlopen: %s",
+                         self.path, dlerror()];
+    return [FBControlCoreError failBoolWithErrorMessage:message
+                                               errorOut:error];
+  } else {
+    [logger.debug logFormat:@"Loaded %@", [self.path lastPathComponent]];
+    return YES;
+  }
+}
+
+@end

--- a/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
+++ b/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
@@ -84,6 +84,12 @@ static BOOL hasLoadedXcodeFrameworks = NO;
     return YES;
   }
 
+  for (FBDependentDylib *dylib in FBDependentDylib.SwiftDylibs) {
+    if (![dylib loadWithLogger:logger error:error]) {
+      return NO;
+    }
+  }
+
   NSArray<FBWeakFramework *> *frameworks = FBDeviceControlFrameworkLoader.privateFrameworks;
 
   if (![FBWeakFrameworkLoader loadPrivateFrameworks:frameworks logger:logger error:error]) {

--- a/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
+++ b/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
@@ -179,12 +179,17 @@ static BOOL hasLoadedXcodeFrameworks = NO;
   return [xcodeVersion compare:xcode81] != NSOrderedAscending;
 }
 
++ (BOOL)xcodeVersionIsLessThan83:(NSDecimalNumber *)xcodeVersion
+{
+  NSDecimalNumber *xcode83 = [NSDecimalNumber decimalNumberWithString:@"8.3"];
+  return [xcodeVersion compare:xcode83] == NSOrderedAscending;
+}
+
 + (NSArray<FBWeakFramework *> *)privateFrameworkForMacOSVersion:(NSOperatingSystemVersion)macOSVersion
                                                    xcodeVersion:(NSDecimalNumber *)xcodeVersion {
   NSArray<FBWeakFramework *> *frameworks =
           @[
                   FBWeakFramework.DTXConnectionServices,
-                  FBWeakFramework.DVTFoundation,
                   FBWeakFramework.IDEFoundation,
                   FBWeakFramework.IDEiOSSupportCore,
                   FBWeakFramework.IBAutolayoutFoundation,
@@ -210,6 +215,13 @@ static BOOL hasLoadedXcodeFrameworks = NO;
     [mutable addObject:FBWeakFramework.DVTKit];
     frameworks = [NSArray arrayWithArray:mutable];
   }
+
+  if ([FBDeviceControlFrameworkLoader xcodeVersionIsLessThan83:xcodeVersion]) {
+    NSMutableArray *mutable = [NSMutableArray arrayWithArray:frameworks];
+    [mutable addObject:FBWeakFramework.DVTFoundation];
+    frameworks = [NSArray arrayWithArray:mutable];
+  }
+
   return frameworks;
 }
 

--- a/FBDeviceControlTests/Tests/Integration/FBDeviceControlLinkerTests.m
+++ b/FBDeviceControlTests/Tests/Integration/FBDeviceControlLinkerTests.m
@@ -26,35 +26,6 @@
     self.continueAfterFailure = NO;
 }
 
-- (void)testTheTest {
-    NSError *err;
-    FBDevice *device = [[FBDeviceSet defaultSetWithLogger:nil
-                                                    error:&err] deviceWithUDID:@"718ab8dbee0173b3f9ebfb01c5688b89221702c6"];
-    
-    if (err) {
-        NSLog(@"Error creating device operator: %@", err);
-        return;
-    }
-
-    
-//    setenv("DEVELOPER_DIR", "/Users/chrisf/Xcodes/8.1/Xcode-beta.app/Contents/Developer", 1);
-    
-    Rep *rep = [Rep new];
-    NSUUID *sessionID = [[NSUUID alloc] initWithUUIDString:@"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"];
-    [FBXCTestRunStrategy startTestManagerForDeviceOperator:device.deviceOperator
-                                            runnerBundleID:@"com.apple.test.DeviceAgent-Runner"
-                                                 sessionID:sessionID
-                                            withAttributes:[FBTestRunnerConfigurationBuilder defaultBuildAttributes]
-                                               environment:[FBTestRunnerConfigurationBuilder defaultBuildEnvironment]
-                                                  reporter:rep
-                                                    logger:FBControlCoreGlobalConfiguration.defaultLogger
-                                                     error:&err];
-     
-    
-    XCTAssertNil(err, @"%@", err);
-    [[NSRunLoop mainRunLoop] run];
-}
-
 + (void)initialize
 {
   if (!NSProcessInfo.processInfo.environment[FBControlCoreStderrLogging]) {

--- a/FBDeviceControlTests/Tests/Unit/FBDeviceControlFrameworkLoaderTests.m
+++ b/FBDeviceControlTests/Tests/Unit/FBDeviceControlFrameworkLoaderTests.m
@@ -15,6 +15,7 @@
 
 + (BOOL)macOSVersionIsAtLeastSierra:(NSOperatingSystemVersion)macOSVersion;
 + (BOOL)xcodeVersionIsAtLeast81:(NSDecimalNumber *)xcodeVersion;
++ (BOOL)xcodeVersionIsLessThan83:(NSDecimalNumber *)xcodeVersion;
 + (NSArray<FBWeakFramework *> *)privateFrameworks;
 + (NSArray<FBWeakFramework *> *)privateFrameworkForMacOSVersion:(NSOperatingSystemVersion)macOSVersion
                                                    xcodeVersion:(NSDecimalNumber *)xcodeVersion;
@@ -61,6 +62,35 @@
   version = [NSDecimalNumber decimalNumberWithString:@"9.0"];
   XCTAssertTrue([FBDeviceControlFrameworkLoader xcodeVersionIsAtLeast81:version],
                 @"Expect Xcode 9.0 be at least 8.1");
+}
+
+- (void)testXcodeVersionIsLessThan83
+{
+    NSDecimalNumber *version;
+
+    version = [NSDecimalNumber decimalNumberWithString:@"7.3.1"];
+    XCTAssertTrue([FBDeviceControlFrameworkLoader xcodeVersionIsLessThan83:version],
+                   @"Expect Xcode 7.3.1 to be less than 8.3");
+
+    version = [NSDecimalNumber decimalNumberWithString:@"8.0"];
+    XCTAssertTrue([FBDeviceControlFrameworkLoader xcodeVersionIsLessThan83:version],
+                   @"Expect Xcode 8.0 to be less than 8.3");
+
+    version = [NSDecimalNumber decimalNumberWithString:@"8.1"];
+    XCTAssertTrue([FBDeviceControlFrameworkLoader xcodeVersionIsLessThan83:version],
+                  @"Expect Xcode 8.1 to be less than 8.3");
+
+    version = [NSDecimalNumber decimalNumberWithString:@"8.2.1"];
+    XCTAssertTrue([FBDeviceControlFrameworkLoader xcodeVersionIsLessThan83:version],
+                  @"Expect Xcode 8.2.1 to be less than 8.3");
+
+    version = [NSDecimalNumber decimalNumberWithString:@"8.3"];
+    XCTAssertFalse([FBDeviceControlFrameworkLoader xcodeVersionIsLessThan83:version],
+                   @"Expect Xcode 8.3 not be less than 8.3");
+
+    version = [NSDecimalNumber decimalNumberWithString:@"9.0"];
+    XCTAssertFalse([FBDeviceControlFrameworkLoader xcodeVersionIsLessThan83:version],
+                   @"Expect Xcode 9.0 not to be less than 8.3");
 }
 
 - (void)testPrivateFrameworks

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -1328,6 +1328,8 @@
 		EEBD60961C908FA200298A07 /* FBJSONConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBJSONConversion.h; sourceTree = "<group>"; };
 		EEF4497B1CE0A22200300C9F /* FBXCTestBootstrapFixtures.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXCTestBootstrapFixtures.h; sourceTree = "<group>"; };
 		EEF4497C1CE0A22200300C9F /* FBXCTestBootstrapFixtures.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXCTestBootstrapFixtures.m; sourceTree = "<group>"; };
+		F550B5901E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = "FBDependentDylib+ApplePrivateDylibs.h"; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F550B5911E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = "FBDependentDylib+ApplePrivateDylibs.m"; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F5ACC7001E51ACD700975101 /* FBDependentDylib.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = FBDependentDylib.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F5ACC7011E51ACD700975101 /* FBDependentDylib.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = FBDependentDylib.m; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
@@ -2699,6 +2701,8 @@
 				AABBF31E1DAC0F9400E2B6AF /* FBTerminationHandle.m */,
 				F5ACC7001E51ACD700975101 /* FBDependentDylib.h */,
 				F5ACC7011E51ACD700975101 /* FBDependentDylib.m */,
+				F550B5901E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h */,
+				F550B5911E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m */,
 				EE2EC7AA1CAC3F97009A7BB1 /* FBWeakFramework.h */,
 				EE2EC7AB1CAC3F97009A7BB1 /* FBWeakFramework.m */,
 				EE2EC7AE1CAC5119009A7BB1 /* FBWeakFramework+ApplePrivateFrameworks.h */,
@@ -2940,8 +2944,8 @@
 				EE9E1E4B1D6CB2CC00860830 /* FBProcessLaunchConfiguration+Helpers.h in Headers */,
 				EEBD606A1C9062E900298A07 /* FBDebugDescribeable.h in Headers */,
 				AAF4C4DF1CDBA1A7004F4AF3 /* FBRunLoopSpinner.h in Headers */,
-				F5ACC7021E51ACD700975101 /* FBDependentDylib.h in Headers */,
 				F550B5921E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h in Headers */,
+				F5ACC7021E51ACD700975101 /* FBDependentDylib.h in Headers */,
 				AAB123821DB4B16900F20555 /* FBDispatchSourceNotifier.h in Headers */,
 				AA7728AE1E5238A6008FCF7C /* FBFileWriter.h in Headers */,
 				AA58F8921D959593006F8D81 /* FBCodesignProvider.h in Headers */,
@@ -3511,6 +3515,7 @@
 				AA391AD31CEF4CBC00817691 /* FBLocalizationOverride.m in Sources */,
 				AAAD5F7C1D5475DE008D3870 /* FBBatchLogSearch.m in Sources */,
 				AA0080D81DB4CCFD009A25CB /* FBProcessTerminationStrategy.m in Sources */,
+				F550B5931E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m in Sources */,
 				EEBD60771C9062E900298A07 /* FBBinaryParser.m in Sources */,
 				AA0F6F2B1CA3DCF700926518 /* FBWeakFrameworkLoader.m in Sources */,
 			);

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -1110,7 +1110,7 @@
 		AAC8B24D1CEC51520034A865 /* FBDeviceControlError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBDeviceControlError.h; sourceTree = "<group>"; };
 		AAC8B24E1CEC51520034A865 /* FBDeviceControlError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBDeviceControlError.m; sourceTree = "<group>"; };
 		AAC8B24F1CEC51520034A865 /* FBDeviceControlFrameworkLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBDeviceControlFrameworkLoader.h; sourceTree = "<group>"; };
-		AAC8B2501CEC51520034A865 /* FBDeviceControlFrameworkLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBDeviceControlFrameworkLoader.m; sourceTree = "<group>"; };
+		AAC8B2501CEC51520034A865 /* FBDeviceControlFrameworkLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = FBDeviceControlFrameworkLoader.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		AAC8B25B1CEC52540034A865 /* FBDeviceControl.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FBDeviceControl.xcconfig; sourceTree = "<group>"; };
 		AAC8B2621CEC55370034A865 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		AACA2C351C2976B100979C45 /* FBAddVideoPolyfill.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBAddVideoPolyfill.h; sourceTree = "<group>"; };

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -475,6 +475,10 @@
 		EEBD60951C908F8500298A07 /* FBCollectionInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = EEBD60931C908F8500298A07 /* FBCollectionInformation.m */; };
 		EEBD60971C908FA200298A07 /* FBJSONConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = EEBD60961C908FA200298A07 /* FBJSONConversion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EEF4497E1CE0A22200300C9F /* FBXCTestBootstrapFixtures.m in Sources */ = {isa = PBXBuildFile; fileRef = EEF4497C1CE0A22200300C9F /* FBXCTestBootstrapFixtures.m */; };
+		F550B5921E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h in Headers */ = {isa = PBXBuildFile; fileRef = F550B5901E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F550B5931E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m in Sources */ = {isa = PBXBuildFile; fileRef = F550B5911E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m */; };
+		F5ACC7021E51ACD700975101 /* FBDependentDylib.h in Headers */ = {isa = PBXBuildFile; fileRef = F5ACC7001E51ACD700975101 /* FBDependentDylib.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F5ACC7031E51ACD700975101 /* FBDependentDylib.m in Sources */ = {isa = PBXBuildFile; fileRef = F5ACC7011E51ACD700975101 /* FBDependentDylib.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1324,6 +1328,8 @@
 		EEBD60961C908FA200298A07 /* FBJSONConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBJSONConversion.h; sourceTree = "<group>"; };
 		EEF4497B1CE0A22200300C9F /* FBXCTestBootstrapFixtures.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXCTestBootstrapFixtures.h; sourceTree = "<group>"; };
 		EEF4497C1CE0A22200300C9F /* FBXCTestBootstrapFixtures.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXCTestBootstrapFixtures.m; sourceTree = "<group>"; };
+		F5ACC7001E51ACD700975101 /* FBDependentDylib.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = FBDependentDylib.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F5ACC7011E51ACD700975101 /* FBDependentDylib.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = FBDependentDylib.m; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2691,6 +2697,8 @@
 				AAD0DE021CEB064200C28B58 /* FBSubstringUtilities.m */,
 				AABBF31D1DAC0F9400E2B6AF /* FBTerminationHandle.h */,
 				AABBF31E1DAC0F9400E2B6AF /* FBTerminationHandle.m */,
+				F5ACC7001E51ACD700975101 /* FBDependentDylib.h */,
+				F5ACC7011E51ACD700975101 /* FBDependentDylib.m */,
 				EE2EC7AA1CAC3F97009A7BB1 /* FBWeakFramework.h */,
 				EE2EC7AB1CAC3F97009A7BB1 /* FBWeakFramework.m */,
 				EE2EC7AE1CAC5119009A7BB1 /* FBWeakFramework+ApplePrivateFrameworks.h */,
@@ -2932,6 +2940,8 @@
 				EE9E1E4B1D6CB2CC00860830 /* FBProcessLaunchConfiguration+Helpers.h in Headers */,
 				EEBD606A1C9062E900298A07 /* FBDebugDescribeable.h in Headers */,
 				AAF4C4DF1CDBA1A7004F4AF3 /* FBRunLoopSpinner.h in Headers */,
+				F5ACC7021E51ACD700975101 /* FBDependentDylib.h in Headers */,
+				F550B5921E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h in Headers */,
 				AAB123821DB4B16900F20555 /* FBDispatchSourceNotifier.h in Headers */,
 				AA7728AE1E5238A6008FCF7C /* FBFileWriter.h in Headers */,
 				AA58F8921D959593006F8D81 /* FBCodesignProvider.h in Headers */,
@@ -3486,6 +3496,7 @@
 				AAE4D05D1D99972B0098A71E /* FBFileManager.m in Sources */,
 				AA1FC91D1D911F6F00A5FCC3 /* FBInteraction.m in Sources */,
 				EEBD60791C9062E900298A07 /* FBCapacityQueue.m in Sources */,
+				F5ACC7031E51ACD700975101 /* FBDependentDylib.m in Sources */,
 				AA6A3B0A1CC0C96E00E016C4 /* FBCollectionOperations.m in Sources */,
 				AA9AAAEC1DE4C3F60056B127 /* FBProcessOutputConfiguration.m in Sources */,
 				EEBD605E1C9062E900298A07 /* FBCrashLogInfo.m in Sources */,

--- a/build.sh
+++ b/build.sh
@@ -231,6 +231,9 @@ Supported Commands:
     Build the xctest exectutable. Optionally copies the executable and it's dependencies to <output-directory>
   fbxctest test
     Builds the FBXCTestKit.framework and runs the tests.
+  fbdevicectl test
+    Builds the FBDeviceControl.framework and runs the tests.
+
 EOF
 }
 
@@ -302,6 +305,14 @@ case $TARGET in
       test)
         build_test_deps
         cli_framework_test fbxctest;;
+      *)
+        echo "Unknown Command $COMMAND"
+        exit 1;;
+    esac;;
+  fbdevicectl)
+    case $COMMAND in
+      test)
+        device_framework_test;;
       *)
         echo "Unknown Command $COMMAND"
         exit 1;;


### PR DESCRIPTION
### Motivation

Loading the DVTFoundation.framework results in internal assertion failures when trying to perform application life cycle actions on physical devices.

```
[MT] DVTAssertions: ASSERTION FAILURE in /Library/Caches/com.apple.xbs/Sources/DVTFrameworks/DVTFrameworks-12125.1/DVTFoundation/DeveloperStructure/DVTExtendedPlatformInfo.m
:53
Details:  Multiple extensions found for platform 'com.apple.platform.macosx' for extension point 'Xcode.DVTFoundation.ExtendedPlatformInfo': {(
        (
        "<DVTExtension 0x7fb39887c1d0: Mac Extended Platform Info (Xcode.DVTFoundation.ExtendedPlatformInfo.Mac) v1.0 from com.apple.dt.DVTFoundation>",
        "/Xcode/8.3/Xcode-beta.app/Contents/SharedFrameworks/DVTFoundation.framework"
    ),
        (
        "<DVTExtension 0x7fb398947960: Mac Extended Platform Info (Xcode.DVTFoundation.ExtendedPlatformInfo.Mac) v1.0 from com.apple.dt.DVTFoundation>",
        "/Xcode/8.3/Xcode-beta.app/Contents/SharedFrameworks/DVTFoundation.framework"
    )
)}
Object:   <DVTExtendedPlatformInfo>
Method:   +extendedPlatformInfoForPlatformIdentifier:error:
Thread:   <NSThread: 0x7fb393e08eb0>{number = 1, name = main}
Hints:

Backtrace:
  0   -[DVTAssertionHandler handleFailureInMethod:object:fileName:lineNumber:assertionSignature:messageFormat:arguments:] (in DVTFoundation)
  1   _DVTAssertionHandler (in DVTFoundation)
  2   _DVTAssertionFailureHandler (in DVTFoundation)
  3   __75+[DVTExtendedPlatformInfo extendedPlatformInfoForPlatformIdentifier:error:]_block_invoke (in DVTFoundation)
  4   _dispatch_client_callout (in libdispatch.dylib)
  5   dispatch_once_f (in libdispatch.dylib)
  6   +[DVTExtendedPlatformInfo extendedPlatformInfoForPlatformIdentifier:error:] (in DVTFoundation)
  7   -[DVTPlatform(DVTExtendedPlatformInfo) dvt_extendedInfoOrError:] (in DVTFoundation)
  8   +[DVTPlatform validatePlatformDataReturningError:] (in DVTFoundation)
  9   IDEInitialize (in IDEFoundation)
 10   +[IDEFoundationTestInitializer initializeTestabilityWithUI:error:] (in IDEFoundation)
 11   +[FBDeviceControlFrameworkLoader initializePrincipalClasses:error:] at /Users/moody/git/calabash/FBSimulatorControl/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m:139 (in FBDeviceControl)
 12   +[FBDeviceControlFrameworkLoader loadXcodeFrameworks:error:] at /Users/moody/git/calabash/FBSimulatorControl/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m:87 (in FBDeviceControl)
 13   __59+[FBDeviceControlFrameworkLoader initializeXCodeFrameworks]_block_invoke at /Users/moody/git/calabash/FBSimulatorControl/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m:75 (in FBDeviceControl)
```

### Notes

Based off **Xcode 8.3 - part 1: Load swift dylibs for Xcode 8.3** #21

### Tests

Skipping El Cap tests until subsequent pull request.

Using iOSDeviceManager to test.

#### macOS Sierra

- [x] Xcode 8.2.1
  - [x] make test-unit
  - [x] make test-integration  (several explainable failures captured in Jira)
  - [x] make test-run-loop
- [x] Xcode 8.3
  - [x] make test-unit
  - [x] make test-integration (several explainable failures captured in Jira)
  - [x] make test-run-loop - fails because `start_test` does not work.

Xcode 8.3 `start_test` failures will be addressed in a subsequent pull request.
