### PR TITLE
DeviceControl can install provisioning profiles on physical devices

### DIFF
--- a/FBDeviceControl/Management/FBAMDevice+Private.h
+++ b/FBDeviceControl/Management/FBAMDevice+Private.h
@@ -33,6 +33,10 @@ extern int (*FBAMDeviceLookupApplications)(CFTypeRef arg0, int arg1, CFDictionar
 extern _Nullable CFStringRef (*_Nonnull FBAMDeviceGetName)(CFTypeRef device);
 extern _Nullable CFStringRef (*_Nonnull FBAMDeviceCopyValue)(CFTypeRef device, _Nullable CFStringRef domain, CFStringRef name);
 
+// Installing provisioning profiles
+extern int (*FBAMDeviceInstallProvisioningProfile)(CFTypeRef device, CFTypeRef profile, void *_Nullable handle);
+extern _Nullable CFTypeRef (*_Nonnull FBMISProfileCreateWithFile)(int arg0, CFStringRef profilePath);
+
 // Debugging
 extern void (*FBAMDSetLogLevel)(int32_t level);
 

--- a/FBDeviceControl/Management/FBAMDevice.m
+++ b/FBDeviceControl/Management/FBAMDevice.m
@@ -64,7 +64,10 @@ static void *FBGetSymbolFromHandle(void *handle, const char *name)
   FBAMDeviceSecureInstallApplication = (int(*)(int, CFTypeRef, CFURLRef, CFDictionaryRef, void *, int))FBGetSymbolFromHandle(handle, "AMDeviceSecureInstallApplication");
   FBAMDeviceSecureUninstallApplication = (int(*)(int, CFTypeRef, CFStringRef, int, void *, int))FBGetSymbolFromHandle(handle, "AMDeviceSecureUninstallApplication");
   FBAMDeviceLookupApplications = (int(*)(CFTypeRef, int, CFDictionaryRef*))FBGetSymbolFromHandle(handle, "AMDeviceLookupApplications");
+  FBAMDeviceInstallProvisioningProfile = (int (*)(CFTypeRef, CFTypeRef, void *))FBGetSymbolFromHandle(handle, "AMDeviceInstallProvisioningProfile");
+  FBMISProfileCreateWithFile = (CFTypeRef(*)(int, CFStringRef))FBGetSymbolFromHandle(handle, "MISProfileCreateWithFile");
 }
+
 + (NSArray<FBAMDevice *> *)allDevices
 {
   NSMutableArray<FBAMDevice *> *devices = [NSMutableArray array];

--- a/FBDeviceControl/Management/FBDevice.m
+++ b/FBDeviceControl/Management/FBDevice.m
@@ -38,6 +38,9 @@ int (*FBAMDeviceSecureTransferPath)(int arg0, CFTypeRef arg1, CFURLRef arg2, CFD
 int (*FBAMDeviceSecureInstallApplication)(int arg0, CFTypeRef arg1, CFURLRef arg2, CFDictionaryRef arg3,  void *_Nullable arg4, int arg5);
 int (*FBAMDeviceSecureUninstallApplication)(int arg0, CFTypeRef arg1, CFStringRef arg2, int arg3, void *_Nullable arg4, int arg5);
 int (*FBAMDeviceLookupApplications)(CFTypeRef arg0, int arg1, CFDictionaryRef *arg2);
+int (*FBAMDeviceInstallProvisioningProfile)(CFTypeRef device, CFTypeRef profile, void *_Nullable handle);
+_Nullable CFTypeRef (*_Nonnull FBMISProfileCreateWithFile)(int arg0, CFStringRef profilePath);
+
 void (*FBAMDSetLogLevel)(int32_t level);
 
 #pragma clang diagnostic push

--- a/FBDeviceControl/Management/FBiOSDeviceOperator.m
+++ b/FBDeviceControl/Management/FBiOSDeviceOperator.m
@@ -136,6 +136,43 @@ static NSString *const ApplicationExecutableKey = @"CFBundleExecutable";
   return productBundle;
 }
 
+- (BOOL)DVTinstallProvisioningProfileAtPath:(NSString *)path error:(NSError **)error
+{
+  __block NSError *innerError = nil;
+  BOOL result = [[FBRunLoopSpinner spinUntilBlockFinished:^id{
+    NSURL *url = [NSURL fileURLWithPath:path];
+    return @([self.device.dvtDevice installProvisioningProfileAtURL:url error:&innerError]);
+  }] boolValue];
+
+  if (*error) { *error = innerError; }
+  return result;
+}
+
+- (BOOL)AMDinstallProvisioningProfileAtPath:(NSString *)path error:(NSError **)error
+{
+  NSNumber *returnCode = [self.device.amDevice handleWithBlockDeviceSession:^id (CFTypeRef device) {
+    NSURL *url = [NSURL fileURLWithPath:path];
+    NSString *encoded = [NSString stringWithUTF8String:[url fileSystemRepresentation]];
+    CFStringRef stringRef = (__bridge CFStringRef)encoded;
+    CFTypeRef profile = FBMISProfileCreateWithFile(0, stringRef);
+    return @(FBAMDeviceInstallProvisioningProfile(device, profile, 0));
+  } error:error];
+
+  if (!returnCode) {
+    [[FBDeviceControlError
+      describe:@"Failed to install application"]
+     failBool:error];
+  }
+
+  if ([returnCode intValue] != 0) {
+    [[FBDeviceControlError
+      describe:@"Failed to install application"]
+     failBool:error];
+  }
+
+  return YES;
+}
+
 - (BOOL)uploadApplicationDataAtPath:(NSString *)path bundleID:(NSString *)bundleID error:(NSError **)error
 {
   __block NSError *innerError = nil;


### PR DESCRIPTION
### Motivation

Adds support for installing provisioning profiles on physical devices using either the `DVTDevice` API or the MobileDevice API.

Progress on:

* DTDKProvisioningProfile API no longer exists in Xcode 9.0 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/11642)




