### PR TITLE
Provide options dictionary to AMDeviceLookupApplications

### DIFF
--- a/FBDeviceControl/Management/FBAMDevice+Private.h
+++ b/FBDeviceControl/Management/FBAMDevice+Private.h
@@ -27,7 +27,7 @@ extern int (*FBAMDeviceSecureStartService)(CFTypeRef device, CFStringRef service
 extern int (*FBAMDeviceSecureTransferPath)(int arg0, CFTypeRef arg1, CFURLRef arg2, CFDictionaryRef arg3, void *_Nullable arg4, int arg5);
 extern int (*FBAMDeviceSecureInstallApplication)(int arg0, CFTypeRef arg1, CFURLRef arg2, CFDictionaryRef arg3, void *_Nullable arg4, int arg5);
 extern int (*FBAMDeviceSecureUninstallApplication)(int arg0, CFTypeRef arg1, CFStringRef arg2, int arg3, void *_Nullable arg4, int arg5);
-extern int (*FBAMDeviceLookupApplications)(CFTypeRef arg0, int arg1, CFDictionaryRef _Nonnull * _Nonnull arg2);
+extern int (*FBAMDeviceLookupApplications)(CFTypeRef arg0, CFDictionaryRef options, CFDictionaryRef _Nonnull * _Nonnull arg2);
 
 // Getting Properties of a Device.
 extern _Nullable CFStringRef (*_Nonnull FBAMDeviceGetName)(CFTypeRef device);

--- a/FBDeviceControl/Management/FBAMDevice.m
+++ b/FBDeviceControl/Management/FBAMDevice.m
@@ -63,7 +63,7 @@ static void *FBGetSymbolFromHandle(void *handle, const char *name)
   FBAMDeviceSecureTransferPath = (int(*)(int, CFTypeRef, CFURLRef, CFDictionaryRef, void *, int))FBGetSymbolFromHandle(handle, "AMDeviceSecureTransferPath");
   FBAMDeviceSecureInstallApplication = (int(*)(int, CFTypeRef, CFURLRef, CFDictionaryRef, void *, int))FBGetSymbolFromHandle(handle, "AMDeviceSecureInstallApplication");
   FBAMDeviceSecureUninstallApplication = (int(*)(int, CFTypeRef, CFStringRef, int, void *, int))FBGetSymbolFromHandle(handle, "AMDeviceSecureUninstallApplication");
-  FBAMDeviceLookupApplications = (int(*)(CFTypeRef, int, CFDictionaryRef*))FBGetSymbolFromHandle(handle, "AMDeviceLookupApplications");
+  FBAMDeviceLookupApplications = (int(*)(CFTypeRef, CFDictionaryRef, CFDictionaryRef*))FBGetSymbolFromHandle(handle, "AMDeviceLookupApplications");
   FBAMDeviceInstallProvisioningProfile = (int (*)(CFTypeRef, CFTypeRef, void *))FBGetSymbolFromHandle(handle, "AMDeviceInstallProvisioningProfile");
   FBMISProfileCreateWithFile = (CFTypeRef(*)(int, CFStringRef))FBGetSymbolFromHandle(handle, "MISProfileCreateWithFile");
 }

--- a/FBDeviceControl/Management/FBDevice.m
+++ b/FBDeviceControl/Management/FBDevice.m
@@ -37,7 +37,7 @@ _Nullable CFStringRef (*_Nonnull FBAMDeviceCopyValue)(CFTypeRef device, _Nullabl
 int (*FBAMDeviceSecureTransferPath)(int arg0, CFTypeRef arg1, CFURLRef arg2, CFDictionaryRef arg3, void *_Nullable arg4, int arg5);
 int (*FBAMDeviceSecureInstallApplication)(int arg0, CFTypeRef arg1, CFURLRef arg2, CFDictionaryRef arg3,  void *_Nullable arg4, int arg5);
 int (*FBAMDeviceSecureUninstallApplication)(int arg0, CFTypeRef arg1, CFStringRef arg2, int arg3, void *_Nullable arg4, int arg5);
-int (*FBAMDeviceLookupApplications)(CFTypeRef arg0, int arg1, CFDictionaryRef *arg2);
+int (*FBAMDeviceLookupApplications)(CFTypeRef arg0, CFDictionaryRef arg1, CFDictionaryRef *arg2);
 int (*FBAMDeviceInstallProvisioningProfile)(CFTypeRef device, CFTypeRef profile, void *_Nullable handle);
 _Nullable CFTypeRef (*_Nonnull FBMISProfileCreateWithFile)(int arg0, CFStringRef profilePath);
 

--- a/FBDeviceControl/Management/FBiOSDeviceOperator.m
+++ b/FBDeviceControl/Management/FBiOSDeviceOperator.m
@@ -352,6 +352,38 @@ static NSString *const ApplicationExecutableKey = @"CFBundleExecutable";
   return (*error == nil);
 }
 
++ (NSDictionary *)applicationReturnAttributesDictionary
+{
+  static NSDictionary *attributes = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSArray *attrs =  @[@"CFBundleIdentifier",
+                        @"ApplicationType",
+                        @"CFBundleExecutable",
+                        @"CFBundleDisplayName",
+                        @"CFBundleName",
+                        @"CFBundleNumericVersion",
+                        @"CFBundleVersion",
+                        @"CFBundleShortVersionString",
+                        @"CFBundleURLTypes",
+                        @"CFBundleDevelopmentRegion",
+                        @"Entitlements",
+                        @"SignerIdentity",
+                        @"ProfileValidated",
+                        @"Path",
+                        @"Container",
+                        @"UIStatusBarTintParameters",
+                        @"UIDeviceFamily",
+                        @"UISupportedInterfaceOrientations",
+                        @"DTPlatformVersion",
+                        @"DTXcode",
+                        @"MinimumOSVersion"
+                        ];
+    attributes = @{@"ReturnAttributes" : attrs};
+  });
+  return attributes;
+}
+
 - (NSArray<NSDictionary<NSString *, id> *> *)installedApplicationsData
 {
   NSMutableArray *applications = [[NSMutableArray alloc] init];

--- a/FBDeviceControl/Management/FBiOSDeviceOperator.m
+++ b/FBDeviceControl/Management/FBiOSDeviceOperator.m
@@ -390,8 +390,9 @@ static NSString *const ApplicationExecutableKey = @"CFBundleExecutable";
 
   __block CFDictionaryRef cf_apps;
 
+  CFDictionaryRef attrs = (__bridge CFDictionaryRef)[FBiOSDeviceOperator applicationReturnAttributesDictionary];
   NSNumber *return_code = [self.device.amDevice handleWithBlockDeviceSession:^id(CFTypeRef device) {
-    return @(FBAMDeviceLookupApplications(device, 0, &cf_apps));
+    return @(FBAMDeviceLookupApplications(device, attrs, &cf_apps));
   } error: nil];
 
   NSDictionary *apps = CFBridgingRelease(cf_apps);


### PR DESCRIPTION
### Movition

Completes:

* FBSimulatorControl: warnings are emitted when inspecting installed apps [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/11817)

Fixes:

```
xctest AMDeviceSlowLookupBreak: AMDeviceLookupApplications was called without
specifying an options dictionary containing kLookupReturnAttributesKey.
This usage is inefficient and may cause performance problems.
Break on AMDeviceSlowLookupBreak to debug.
```
