### PR TITLE
DeviceControl: update swift dylib loading for Xcode 9

### DIFF
--- a/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
+++ b/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
@@ -32,21 +32,32 @@
   NSDecimalNumber *xcode83 = [NSDecimalNumber decimalNumberWithString:@"8.3"];
   BOOL atLeastXcode83 = [xcodeVersion compare:xcode83] != NSOrderedAscending;
 
+  NSDecimalNumber *xcode90 = [NSDecimalNumber decimalNumberWithString:@"9.0"];
+  BOOL atLeastXcode90 = [xcodeVersion compare:xcode90] != NSOrderedAscending;
+
   if (atLeastXcode83) {
-    return @[
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCore.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDarwin.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftObjectiveC.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDispatch.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftIOKit.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreGraphics.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftFoundation.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftXPC.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreImage.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftQuartzCore.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreData.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftAppKit.dylib"],
-             ];
+    NSArray *dylibs =
+    @[
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCore.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDarwin.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftObjectiveC.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDispatch.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftIOKit.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreGraphics.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftFoundation.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftXPC.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreImage.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftQuartzCore.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreData.dylib"],
+      [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftAppKit.dylib"]
+      ];
+    if (atLeastXcode90) {
+      NSMutableArray *mutable = [NSMutableArray arrayWithArray:dylibs];
+      FBDependentDylib *dylib = [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreFoundation.dylib"];
+      [mutable insertObject:dylib atIndex:4];
+      dylibs = [NSArray arrayWithArray:mutable];
+    }
+    return dylibs;
   } else {
     // No swift dylibs are required.
     return @[];


### PR DESCRIPTION
### Motivation

Fixes:

* FBSimulatorControl cannot load Swift libs in Xcode 9 beta 3 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/10832)

