### PR TITLE
DeviceControl: load additional Xcode 9 IDE frameworks

### DIFF
--- a/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.h
+++ b/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)IDESourceEditor;
 + (instancetype)DFRSupportKit;
 + (instancetype)DVTKit;
++ (instancetype)DebugHierarchyFoundation;
++ (instancetype)DebugHierarchyKit;
 
 /**
  XCTest framework for MacOSX

--- a/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.m
+++ b/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.m
@@ -97,6 +97,16 @@
   return [FBWeakFramework xcodeFrameworkWithRelativePath:@"../SharedFrameworks/DVTKit.framework"];
 }
 
++ (nonnull instancetype)DebugHierarchyFoundation
+{
+  return [FBWeakFramework xcodeFrameworkWithRelativePath:@"../SharedFrameworks/DebugHierarchyFoundation.framework"];
+}
+
++ (instancetype)DebugHierarchyKit
+{
+  return [FBWeakFramework xcodeFrameworkWithRelativePath:@"../SharedFrameworks/DebugHierarchyKit.framework"];
+}
+
 + (instancetype)ConfigurationUtilityKit
 {
   return [FBWeakFramework

--- a/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
+++ b/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
@@ -185,6 +185,12 @@ static BOOL hasLoadedXcodeFrameworks = NO;
   return [xcodeVersion compare:xcode83] == NSOrderedAscending;
 }
 
++ (BOOL)xcodeVersionIsAtLeast90:(NSDecimalNumber *)xcodeVersion
+{
+  NSDecimalNumber *xcode90 = [NSDecimalNumber decimalNumberWithString:@"9.0"];
+  return [xcodeVersion compare:xcode90] != NSOrderedAscending;
+}
+
 + (NSArray<FBWeakFramework *> *)privateFrameworkForMacOSVersion:(NSOperatingSystemVersion)macOSVersion
                                                    xcodeVersion:(NSDecimalNumber *)xcodeVersion {
   NSArray<FBWeakFramework *> *frameworks =
@@ -219,6 +225,13 @@ static BOOL hasLoadedXcodeFrameworks = NO;
   if ([FBDeviceControlFrameworkLoader xcodeVersionIsLessThan83:xcodeVersion]) {
     NSMutableArray *mutable = [NSMutableArray arrayWithArray:frameworks];
     [mutable addObject:FBWeakFramework.DVTFoundation];
+    frameworks = [NSArray arrayWithArray:mutable];
+  }
+
+  if ([FBDeviceControlFrameworkLoader xcodeVersionIsAtLeast90:xcodeVersion]) {
+    NSMutableArray *mutable = [NSMutableArray arrayWithArray:frameworks];
+    [mutable addObject:FBWeakFramework.DebugHierarchyFoundation];
+    [mutable addObject:FBWeakFramework.DebugHierarchyKit];
     frameworks = [NSArray arrayWithArray:mutable];
   }
 

--- a/FBDeviceControlTests/Tests/Unit/FBDeviceControlFrameworkLoaderTests.m
+++ b/FBDeviceControlTests/Tests/Unit/FBDeviceControlFrameworkLoaderTests.m
@@ -16,6 +16,7 @@
 + (BOOL)macOSVersionIsAtLeastSierra:(NSOperatingSystemVersion)macOSVersion;
 + (BOOL)xcodeVersionIsAtLeast81:(NSDecimalNumber *)xcodeVersion;
 + (BOOL)xcodeVersionIsLessThan83:(NSDecimalNumber *)xcodeVersion;
++ (BOOL)xcodeVersionIsAtLeast90:(NSDecimalNumber *)xcodeVersion;
 + (NSArray<FBWeakFramework *> *)privateFrameworks;
 + (NSArray<FBWeakFramework *> *)privateFrameworkForMacOSVersion:(NSOperatingSystemVersion)macOSVersion
                                                    xcodeVersion:(NSDecimalNumber *)xcodeVersion;
@@ -91,6 +92,31 @@
     version = [NSDecimalNumber decimalNumberWithString:@"9.0"];
     XCTAssertFalse([FBDeviceControlFrameworkLoader xcodeVersionIsLessThan83:version],
                    @"Expect Xcode 9.0 not to be less than 8.3");
+}
+
+- (void)testXcodeVersionIsAtLeast90
+{
+  NSDecimalNumber *version;
+
+  version = [NSDecimalNumber decimalNumberWithString:@"7.3.1"];
+  XCTAssertFalse([FBDeviceControlFrameworkLoader xcodeVersionIsAtLeast90:version],
+                 @"Expect Xcode 7.3.1 not to be at least 9.0");
+
+  version = [NSDecimalNumber decimalNumberWithString:@"8.3.3"];
+  XCTAssertFalse([FBDeviceControlFrameworkLoader xcodeVersionIsAtLeast90:version],
+                 @"Expect Xcode 8.3.3 not to be at least 9.0");
+
+  version = [NSDecimalNumber decimalNumberWithString:@"9.0"];
+  XCTAssertTrue([FBDeviceControlFrameworkLoader xcodeVersionIsAtLeast90:version],
+                @"Expect Xcode 9.0 be at least 9.0");
+
+  version = [NSDecimalNumber decimalNumberWithString:@"9.1"];
+  XCTAssertTrue([FBDeviceControlFrameworkLoader xcodeVersionIsAtLeast90:version],
+                @"Expect Xcode 9.1 be at least 9.0");
+
+  version = [NSDecimalNumber decimalNumberWithString:@"10.0"];
+  XCTAssertTrue([FBDeviceControlFrameworkLoader xcodeVersionIsAtLeast90:version],
+                @"Expect Xcode 10.0 be at least 9.0");
 }
 
 - (void)testPrivateFrameworks
@@ -183,8 +209,8 @@
   frameworks = [FBDeviceControlFrameworkLoader privateFrameworkForMacOSVersion:sierra
                                                                   xcodeVersion:xcodeVersion];
 
-  XCTAssertTrue(frameworks.count == 8,
-                @"Expected exactly 8 frameworks for Sierra for Xcode >= 8.3");
+  XCTAssertTrue(frameworks.count == 10,
+                @"Expected exactly 10 frameworks for Sierra for Xcode >= 9.0");
 }
 
 @end


### PR DESCRIPTION
### Motivation

Fixes:

* FBSimulatorControl: DVTPlugInManager cannot load MobileDevice because of missing frameworks on Xcode 9 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/11878)