### PR TITLE
Allow frameworks to be built with Xcode 9 and still used with Xcode 8

### DIFF
--- a/Configuration/Shared.xcconfig
+++ b/Configuration/Shared.xcconfig
@@ -61,7 +61,7 @@ APPLE_SHARED_FRAMEWORKS_DIR = $(DEVELOPER_DIR)/../SharedFrameworks
 
 // Search Paths for Frameworks & Headers
 ALWAYS_SEARCH_USER_PATHS = NO
-FRAMEWORK_SEARCH_PATHS = $(inherited) $(APPLE_FRAMEWORKS_DIR) $(APPLE_PLUGINS_DIR) $(APPLE_OTHER_FRAMEWORKS_DIR) $(APPLE_SHARED_FRAMEWORKS_DIR) $(DEVELOPER_LIBRARY_DIR)/PrivateFrameworks $(SDKROOT)/System/Library/PrivateFrameworks /Library/Developer/PrivateFrameworks
+FRAMEWORK_SEARCH_PATHS = $(inherited) $(APPLE_FRAMEWORKS_DIR) $(APPLE_PLUGINS_DIR) $(APPLE_OTHER_FRAMEWORKS_DIR) $(APPLE_SHARED_FRAMEWORKS_DIR) $(DEVELOPER_LIBRARY_DIR)/PrivateFrameworks $(SDKROOT)/System/Library/PrivateFrameworks
 HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/PrivateHeaders
 
 // SDK & OS Versions

--- a/FBControlCore/Utility/FBControlCoreFrameworkLoader.m
+++ b/FBControlCore/Utility/FBControlCoreFrameworkLoader.m
@@ -74,7 +74,7 @@ void *FBGetSymbolFromHandle(void *handle, const char *name)
   if (success) {
     return;
   }
-  NSString *message = [NSString stringWithFormat:@"Failed to private frameworks for %@ with error %@", self.frameworkName, error];
+  NSString *message = [NSString stringWithFormat:@"Failed to load private frameworks for %@ with error %@", self.frameworkName, error];
 
   // Log the message.
   [logger.error log:message];

--- a/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.m
+++ b/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.m
@@ -18,8 +18,9 @@
 {
   if (FBXcodeConfiguration.isXcode9OrGreater) {
     return [FBWeakFramework frameworkWithPath:@"/Library/Developer/PrivateFrameworks/CoreSimulator.framework" requiredClassNames:@[@"SimDevice"]];
+  } else {
+    return [FBWeakFramework xcodeFrameworkWithRelativePath:@"Library/PrivateFrameworks/CoreSimulator.framework" requiredClassNames:@[@"SimDevice"]];
   }
-  return [FBWeakFramework xcodeFrameworkWithRelativePath:@"Library/PrivateFrameworks/CoreSimulator.framework" requiredClassNames:@[@"SimDevice"]];
 }
 
 + (nonnull instancetype)SimulatorKit

--- a/FBControlCore/Utility/FBWeakFramework.m
+++ b/FBControlCore/Utility/FBWeakFramework.m
@@ -272,7 +272,7 @@
   NSString *basePath = [[self.basePath stringByDeletingLastPathComponent] stringByDeletingLastPathComponent];
   if (![bundle.bundlePath hasPrefix:basePath]) {
     return [[FBControlCoreError
-      describeFormat:@"Expected Framework %@ to be loaded for Developer Directory at path %@, but was loaded from %@", bundle.bundlePath.lastPathComponent, bundle.bundlePath, self.basePath]
+      describeFormat:@"Expected %@ to be loaded from library at path %@, but was loaded from %@", bundle.bundlePath.lastPathComponent, bundle.bundlePath, self.basePath]
       failBool:error];
   }
   [logger.debug logFormat:@"%@: %@ has correct path of %@", self.name, className, basePath];

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -4076,6 +4076,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor",
 				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
@@ -4102,6 +4103,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor",
 				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Profile;
@@ -4125,6 +4127,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor",
 				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;

--- a/FBSimulatorControl/FBSimulatorControl.xcconfig
+++ b/FBSimulatorControl/FBSimulatorControl.xcconfig
@@ -3,7 +3,7 @@
 #include "../Configuration/Framework.xcconfig"
 
 // Weak-Link Xcode Private Frameworks
-OTHER_LDFLAGS = $(inherited) -weak_framework DVTFoundation -weak_framework DVTiPhoneSimulatorRemoteClient -weak_framework CoreSimulator -weak_framework SimulatorKit
+OTHER_LDFLAGS = $(inherited) -weak_framework DVTFoundation -weak_framework DVTiPhoneSimulatorRemoteClient -weak_framework SimulatorKit
 
 // Target-Specific Settings
 INFOPLIST_FILE = $(SRCROOT)/FBSimulatorControl/FBSimulatorControl-Info.plist;


### PR DESCRIPTION
### Motivation

When the frameworks are built with Xcode 9, they are not usable with Xcode 8.

```
Assertion failure in -[FBSimulatorControlFrameworkLoader loadPrivateFrameworksOrAbort], 
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', 
reason: 'Failed to private frameworks for FBSimulatorControl with error Error 

Expected CoreSimulator.framework to be loaded from library at path
  /Library/Developer/PrivateFrameworks/CoreSimulator.framework, 

but was loaded from

 /Xcode/8.3.3/Xcode.app/Contents/Developer
```

### Analysis

When a user installs Xcode 9, this framework is installed:

 ```
/Library/Developer/PrivateFrameworks/CoreSimulator.framework
```

The build settings for the FBSimulatorControl.framework include: 

```
/Library/Developer/PrivateFrameworks
```

in the Framework Search Path, presumably so the FBSimulatorControl.framework can weak link against `CoreSimulator.framework`

```
OTHER_LDFLAGS=-weak_framework CoreSimulator
```

There is branch on Xcode version at _runtime_ that looks like this:

```
if Xcode >= 9
  load /Library/Developer/PrivateFrameworks/CoreSimulator.framework
else
  load /Xcode/<version>/Contents/Developer/path/to/CoreSimulator.framework
end
```

The error is that when Xcode 8 is the active Xcode, something is loading the `SimDevice` class from `/Library/Developer/PrivateFrameworks/CoreSimulator.framework` and not from `/Xcode/<version>/Contents/Developer/path/to/CoreSimulator.framework`.

The problem is that CoreSimulator.framework in the framework search path _regardless of Xcode version_ and `CoreSimulator.framework` is linked so `SimDevice` will always be loaded from that library (if it exists).

Why is CoreSimulator.framework linked at all?  It should be loaded at runtime.

### Tests

```
$ be rspec spec/launch_simulator_spec.rb
Randomized with seed 15966

launch-simulator
  quits running Simlator.app if --device-id is not the same
  does not quit running Simlator.app if --device-id is the same
  launches the simulator indicated by --device-id

$ DEVELOPER_DIR=/Xcode/8.3.3/Xcode.app/Contents/Developer \
  be rspec spec/launch_simulator_spec.rb
Randomized with seed 51545

launch-simulator
  quits running Simlator.app if --device-id is not the same
  launches the simulator indicated by --device-id
  does not quit running Simlator.app if --device-id is the same
```

