### PR TITLE
Xcode 9.3 beta 2 support

### DIFF
--- a/FBControlCore/Configuration/FBControlCoreConfigurationVariants.h
+++ b/FBControlCore/Configuration/FBControlCoreConfigurationVariants.h
@@ -92,6 +92,7 @@ extern FBOSVersionName const FBOSVersionNameiOS_10_3;
 extern FBOSVersionName const FBOSVersionNameiOS_11_0;
 extern FBOSVersionName const FBOSVersionNameiOS_11_1;
 extern FBOSVersionName const FBOSVersionNameiOS_11_2;
+extern FBOSVersionName const FBOSVersionNameiOS_11_3;
 extern FBOSVersionName const FBOSVersionNametvOS_9_0;
 extern FBOSVersionName const FBOSVersionNametvOS_9_1;
 extern FBOSVersionName const FBOSVersionNametvOS_9_2;

--- a/FBControlCore/Configuration/FBControlCoreConfigurationVariants.m
+++ b/FBControlCore/Configuration/FBControlCoreConfigurationVariants.m
@@ -70,6 +70,7 @@ FBOSVersionName const FBOSVersionNameiOS_10_3 = @"iOS 10.3";
 FBOSVersionName const FBOSVersionNameiOS_11_0 = @"iOS 11.0";
 FBOSVersionName const FBOSVersionNameiOS_11_1 = @"iOS 11.1";
 FBOSVersionName const FBOSVersionNameiOS_11_2 = @"iOS 11.2";
+FBOSVersionName const FBOSVersionNameiOS_11_3 = @"iOS 11.3";
 FBOSVersionName const FBOSVersionNametvOS_9_0 = @"tvOS 9.0";
 FBOSVersionName const FBOSVersionNametvOS_9_1 = @"tvOS 9.1";
 FBOSVersionName const FBOSVersionNametvOS_9_2 = @"tvOS 9.2";
@@ -337,6 +338,7 @@ FBOSVersionName const FBOSVersionNamewatchOS_4_2 = @"watchOS 4.2";
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_11_0],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_11_1],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_11_2],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_11_3],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_0],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_1],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_2],

--- a/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
+++ b/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
@@ -104,7 +104,15 @@
   if (![objc_lookUpClass("DVTDeviceType") deviceTypeWithIdentifier:@"Xcode.DeviceType.iPhone"]) {
     return [[[FBDeviceControlError describe:@"Device Type 'Xcode.DeviceType.iPhone' hasn't been initialized yet"] causedBy:innerError] failBool:error];
   }
-  [[objc_lookUpClass("DVTDeviceManager") defaultDeviceManager] startLocating];
+
+  /*
+   Starting in Xcode 9.3, this raises an internal error.  Prior to Xcode 9.3,
+   this call is required.
+   */
+  NSDecimalNumber *xcodeVersion = FBXcodeConfiguration.xcodeVersionNumber;
+  if (![FBDeviceControlFrameworkLoader xcodeVersionIsAtLeast93:xcodeVersion]) {
+     [[objc_lookUpClass("DVTDeviceManager") defaultDeviceManager] startLocating];
+  }
   return YES;
 }
 
@@ -139,6 +147,12 @@
 {
   NSDecimalNumber *xcode90 = [NSDecimalNumber decimalNumberWithString:@"9.0"];
   return [xcodeVersion compare:xcode90] != NSOrderedAscending;
+}
+
++ (BOOL)xcodeVersionIsAtLeast93:(NSDecimalNumber *)xcodeVersion
+{
+  NSDecimalNumber *xcode93 = [NSDecimalNumber decimalNumberWithString:@"9.3"];
+  return [xcodeVersion compare:xcode93] != NSOrderedAscending;
 }
 
 + (NSArray<FBWeakFramework *> *)privateFrameworkForMacOSVersion:(NSOperatingSystemVersion)macOSVersion
@@ -196,7 +210,6 @@
   return [FBDeviceControlFrameworkLoader privateFrameworkForMacOSVersion:macOSVersion
                                                             xcodeVersion:xcodeVersion];
 }
-
 
 @end
 

--- a/FORK_MAINTENANCE.md
+++ b/FORK_MAINTENANCE.md
@@ -1,3 +1,15 @@
+## Update
+
+We have not merged FBSimulatorControl master to this fork since
+18 Aug 2017.  Facebook has not been merging our pull requests
+fast enough or at all.
+
+We are working off our own /develop branch - creating tags as
+new Xcode versions are introduced.
+
+The rest of this document describes how we would interact with
+this repo's upstream if Facebook were more responsive.
+
 ### Maintenance
 
 The master branch of our fork will be kept in step with the upstream
@@ -47,6 +59,7 @@ upstream        git@github.com:facebook/FBSimulatorControl.git (push)
 $ git co master
 $ git pull origin master
 $ git fetch upstream master
+$ git merge upstream/master
 
 $ git co develop
 $ git pull origin develop


### PR DESCRIPTION
### Motivation

Xcode 9.3 betas are out

### Test

#### Unit

- [x] macOS Sierra
- [x] macOS High Sierra

#### RSpec

- [x] macOS Sierra
  - [x] Xcode 9.3 - not supported 
  - [x] Xcode 9.2
    - [x] simulators
    - [x] iOS 10 device

- [x] macOS High Sierra
  - [x] Xcode 9.3 beta 2
    - [x] simulators
    - [x] iOS 10 device
    - [x] iOS 11.3 beta device
  - [x] Xcode 9.2
    - [x] simulators
    - [x] iOS 10 device

#### XCTest Integration

These tests are in the process of being replaced with rspec tests.

There are explainable failures around uploading xctestdata bundles and the CLI tests.

- [x] macOS Sierra
  - [x] Xcode 9.3 - not supported 
  - [x] Xcode 9.2
    - [x] simulators
    - [x] iOS 10 device

- [x] macOS High Sierra
  - [x] Xcode 9.3 beta 2
    - [x] simulators
    - [x] iOS 10 device
    - [x] iOS 11.3 beta device
  - [x] Xcode 9.2
    - [x] simulators
    - [x] iOS 10 device