### PR TITLE
Feature/initial xcode 10 exploration

### DIFF
--- a/FBControlCore/Configuration/FBControlCoreConfigurationVariants.h
+++ b/FBControlCore/Configuration/FBControlCoreConfigurationVariants.h
@@ -96,6 +96,7 @@ extern FBOSVersionName const FBOSVersionNameiOS_11_1;
 extern FBOSVersionName const FBOSVersionNameiOS_11_2;
 extern FBOSVersionName const FBOSVersionNameiOS_11_3;
 extern FBOSVersionName const FBOSVersionNameiOS_11_4;
+extern FBOSVersionName const FBOSVersionNameiOS_12_0;
 extern FBOSVersionName const FBOSVersionNametvOS_9_0;
 extern FBOSVersionName const FBOSVersionNametvOS_9_1;
 extern FBOSVersionName const FBOSVersionNametvOS_9_2;

--- a/FBControlCore/Configuration/FBControlCoreConfigurationVariants.m
+++ b/FBControlCore/Configuration/FBControlCoreConfigurationVariants.m
@@ -74,6 +74,7 @@ FBOSVersionName const FBOSVersionNameiOS_11_1 = @"iOS 11.1";
 FBOSVersionName const FBOSVersionNameiOS_11_2 = @"iOS 11.2";
 FBOSVersionName const FBOSVersionNameiOS_11_3 = @"iOS 11.3";
 FBOSVersionName const FBOSVersionNameiOS_11_4 = @"iOS 11.4";
+FBOSVersionName const FBOSVersionNameiOS_12_0 = @"iOS 12.0";
 FBOSVersionName const FBOSVersionNametvOS_9_0 = @"tvOS 9.0";
 FBOSVersionName const FBOSVersionNametvOS_9_1 = @"tvOS 9.1";
 FBOSVersionName const FBOSVersionNametvOS_9_2 = @"tvOS 9.2";
@@ -343,6 +344,7 @@ FBOSVersionName const FBOSVersionNamewatchOS_4_2 = @"watchOS 4.2";
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_11_2],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_11_3],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_11_4],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_12_0],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_0],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_1],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_2],

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -110,8 +110,6 @@
 		AA2076C81F0B7542001F180C /* FBUploadBufferTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2076B71F0B7541001F180C /* FBUploadBufferTests.m */; };
 		AA2076D01F0B76AF001F180C /* FBFileWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2076CF1F0B76AF001F180C /* FBFileWriterTests.m */; };
 		AA2076D21F0B779B001F180C /* FBFileReaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2076D11F0B779B001F180C /* FBFileReaderTests.m */; };
-		AA2076D51F0B7CE8001F180C /* FBSocketWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2076D31F0B7CE8001F180C /* FBSocketWriter.m */; };
-		AA2076D61F0B7CE8001F180C /* FBSocketWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2076D41F0B7CE8001F180C /* FBSocketWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA2076D81F0B7D03001F180C /* FBSocketIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2076D71F0B7D03001F180C /* FBSocketIntegrationTests.m */; };
 		AA21258F1F04E08400FB6032 /* FBSimulatorHIDIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA21258E1F04E08300FB6032 /* FBSimulatorHIDIntegrationTests.m */; };
 		AA25770A1DF16B1300789490 /* FBDefaultsModificationStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2577081DF16B1300789490 /* FBDefaultsModificationStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3519,7 +3517,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = FB;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					AA819DB11B9FB40D002F58CA = {
@@ -3955,7 +3953,6 @@
 				EEBD605C1C9062E900298A07 /* FBASLParser.m in Sources */,
 				AAD0DE041CEB064200C28B58 /* FBSubstringUtilities.m in Sources */,
 				F5CFE3EB1F051EEC003B3297 /* FBDependentDylib+ApplePrivateDylibs.m in Sources */,
-				AAD414AB1E4E2F3100815112 /* FBSocketReader.m in Sources */,
 				AA6D511E1E96BE68003B5582 /* FBiOSActionReader.m in Sources */,
 				AA4A7E2E1DD9F4EB001F9D8E /* FBFileReader.m in Sources */,
 				AA2942811D00AB0800880984 /* FBiOSTarget.m in Sources */,
@@ -4004,7 +4001,6 @@
 				AA2076BA1F0B7542001F180C /* FBBitmapStreamConfigurationTests.m in Sources */,
 				AA2076B81F0B7542001F180C /* FBiOSActionReaderTests.m in Sources */,
 				AA3B92B11DD1C716000C045B /* FBControlCoreLoggerDouble.m in Sources */,
-				AA2076C71F0B7542001F180C /* FBProcessOutputConfigurationTests.m in Sources */,
 				AA30A4A21F3C941200EA4B2A /* FBiOSTargetActionTests.m in Sources */,
 				AA2076D21F0B779B001F180C /* FBFileReaderTests.m in Sources */,
 			);

--- a/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBControlCore.xcscheme
+++ b/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBControlCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBDeviceControl.xcscheme
+++ b/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBDeviceControl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBSimulatorControl.xcscheme
+++ b/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBSimulatorControl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/XCTestBootstrap.xcscheme
+++ b/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/XCTestBootstrap.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FBSimulatorControl/Management/FBSimulatorBridge.m
+++ b/FBSimulatorControl/Management/FBSimulatorBridge.m
@@ -56,10 +56,11 @@
 
   // Load Accessibility, return early if this fails
   [bridge enableAccessibility];
-  if (![bridge accessibilityEnabled]) {
+  SEL knownSelector = @selector(setLocationScenarioWithPath:);
+  if (![bridge respondsToSelector:knownSelector]) {
     return [[FBSimulatorError
-      describeFormat:@"Could not enable accessibility for bridge '%@'", bridge]
-      fail:error];
+             describeFormat:@"Object '%@' for '%@' isn't a SimulatorBridge as it doesn't respond to %@", portName, bridge, NSStringFromSelector(knownSelector)]
+            fail:error];
   }
 
   return [[FBSimulatorBridge alloc] initWithBridge:bridge operation:operation];

--- a/PrivateHeaders/SimulatorApp/Indigo.h
+++ b/PrivateHeaders/SimulatorApp/Indigo.h
@@ -14,7 +14,7 @@
 
 #import <SimulatorApp/Mach.h>
 
-#pragma pack(4)
+#pragma pack(push, 4)
 
 /**
  A Quad that is sent via Indigo.
@@ -160,4 +160,4 @@ typedef struct {
 #define IndigoEventTypeTouch 2
 #define IndigoEventTypeUnknown 3
 
-#pragma pack(4)
+#pragma pack(pop)

--- a/PrivateHeaders/SimulatorApp/Mach.h
+++ b/PrivateHeaders/SimulatorApp/Mach.h
@@ -9,7 +9,7 @@
 
 //#import <mach/mach.h>
 
-#pragma pack(4)
+#pragma pack(push, 4)
 
 /**
  Annotation of the mach_msg_header_t with offsets
@@ -23,4 +23,4 @@ typedef struct {
   int msgh_id; // 0x14
 } MachMessageHeader;
 
-#pragma pack()
+#pragma pack(pop)


### PR DESCRIPTION
[VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/Krukow-M1-Team/_workitems/edit/41231)

### Update FBSimulatorControl for Xcode 10
- Added constants for iOS 12
- Fixed `#pragma` issue in PrivateHeaders
- Update FBSimulatorControl due to lack of `accessibilityEnabled` property on `SimulatorBridge` in Xcode 10