### PR TITLE
Fix incompatibility with Xcode 10.2

### DIFF
--- a/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
+++ b/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
@@ -42,25 +42,25 @@
   BOOL atLeastXcode102 = [xcodeVersion compare:xcode102] != NSOrderedAscending;
   // dylibs not required prior to Xcode 8.3.3
   NSArray *dylibs = @[];
-if ( atLeastXcode102) {
-    dylibs =     @[
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCore.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftDarwin.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftObjectiveC.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftDispatch.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCoreFoundation.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftIOKit.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCoreGraphics.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftFoundation.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftXPC.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftos.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftMetal.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCoreImage.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftQuartzCore.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCoreData.dylib"],
-       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftAppKit.dylib"]
-       ];
-    
+if (atLeastXcode102) {
+    dylibs =
+    @[
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftCore.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftDarwin.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftObjectiveC.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftDispatch.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftCoreFoundation.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftIOKit.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftCoreGraphics.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftFoundation.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftXPC.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftos.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftMetal.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftCoreImage.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftQuartzCore.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftCoreData.dylib"],
+       [FBDependentDylib dependentWithAbsolutePath:@"/usr/lib/swift/libswiftAppKit.dylib"]
+     ];
 } else if (atLeastXcode90) {
     dylibs =
     @[

--- a/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
+++ b/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
@@ -38,10 +38,30 @@
   NSDecimalNumber *xcode90 = [NSDecimalNumber decimalNumberWithString:@"9.0"];
   BOOL atLeastXcode90 = [xcodeVersion compare:xcode90] != NSOrderedAscending;
 
+  NSDecimalNumber *xcode102 = [NSDecimalNumber decimalNumberWithString:@"10.2"];
+  BOOL atLeastXcode102 = [xcodeVersion compare:xcode102] != NSOrderedAscending;
   // dylibs not required prior to Xcode 8.3.3
   NSArray *dylibs = @[];
-
-  if (atLeastXcode90) {
+if ( atLeastXcode102) {
+    dylibs =     @[
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCore.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftDarwin.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftObjectiveC.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftDispatch.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCoreFoundation.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftIOKit.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCoreGraphics.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftFoundation.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftXPC.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftos.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftMetal.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCoreImage.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftQuartzCore.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftCoreData.dylib"],
+       [FBDependentDylib dependentWithRelativePath:@"../../../../../../usr/lib/swift/libswiftAppKit.dylib"]
+       ];
+    
+} else if (atLeastXcode90) {
     dylibs =
     @[
       [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCore.dylib"],

--- a/FBControlCore/Utility/FBDependentDylib.h
+++ b/FBControlCore/Utility/FBDependentDylib.h
@@ -28,6 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)dependentWithRelativePath:(NSString *)relativePath;
 
+/**
+ Creates and returns FBDependentDylib with the given path.
+ 
+ @param absolutePath absolute path to Swift libs directory
+ @return an FBDependentDylib instance
+ */
++ (instancetype)dependentWithAbsolutePath:(NSString *)absolutePath;
 
 /**
  Loads the framework using dlopen.

--- a/FBControlCore/Utility/FBDependentDylib.m
+++ b/FBControlCore/Utility/FBDependentDylib.m
@@ -42,6 +42,20 @@
   return self;
 }
 
++ (instancetype)dependentWithAbsolutePath:(NSString *)absolutePath
+{
+    return [[FBDependentDylib alloc] initWithAbsolutePath:absolutePath];
+}
+
+- (instancetype)initWithAbsolutePath:(NSString *)absolutePath
+{
+    self = [super init];
+    if (self) {
+        _path = [absolutePath stringByStandardizingPath];
+    }
+    return self;
+}
+
 #pragma mark Public
 
 - (BOOL)loadWithLogger:(id<FBControlCoreLogger>)logger error:(NSError **)error


### PR DESCRIPTION
Error on running spec test on physical devices:  
`This copy of libswiftCore.dylib requires an OS version prior to 10.14.4.`

### Repro steps:
1. connect physical device
2. cd .../iOSDeviceManager
3. bundle install
4. DEVICE=1 make rspec 

### Log:
![image](https://user-images.githubusercontent.com/40772628/55614561-f7c2e780-5795-11e9-8213-054bfef083a3.png)

### Changes:
Providing `/usr/lib/swift` as dylib paths if Xcode >= 10.2, it should load platform libraries.

### [Xcode 10.2 Release Notes](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes/swift_5_release_notes_for_xcode_10_2?language=objc):
> #### Swift 5 Runtime Support for Command Line Tools Package
> Starting with Xcode 10.2, Swift command line tools require the Swift libraries in macOS. They’re included by default starting with macOS Mojave 10.14.4. In macOS Mojave 10.14.3 and earlier, there’s an optional package to provide these runtime support libraries for Swift command line tools