### PR TITLE
Update deprecated method

### DIFF
--- a/FBDeviceControl/Management/FBiOSDeviceOperator.m
+++ b/FBDeviceControl/Management/FBiOSDeviceOperator.m
@@ -319,7 +319,7 @@
       failBool:error];
   }
 
-  if (!self.device.dvtDevice.serviceHubProcessControlChannel) {
+  if (![self.device.dvtDevice makeServiceHubProcessControlChannelForLauncher:0]) {
     return [[FBDeviceControlError
       describe:@"Failed to create HUB control channel"]
       failBool:error];
@@ -499,7 +499,7 @@
   id result = [FBRunLoopSpinner spinUntilBlockFinished:^id{
     __block id responseObject;
 
-    DTXChannel *channel = self.device.dvtDevice.serviceHubProcessControlChannel;
+    DTXChannel *channel = [self.device.dvtDevice makeServiceHubProcessControlChannelForLauncher:0];
     DTXMessage *message = [[objc_lookUpClass("DTXMessage") alloc] initWithSelector:aSelector firstArg:arg remainingObjectArgs:(__bridge id)(*arguments)];
     [channel sendControlSync:message replyHandler:^(DTXMessage *responseMessage){
       if (responseMessage.errorStatus) {

--- a/PrivateHeaders/DVTFoundation/DVTDevice.h
+++ b/PrivateHeaders/DVTFoundation/DVTDevice.h
@@ -92,6 +92,7 @@
 - (void)_resourceControlChannel:(id)arg1 completionBlock:(CDUnknownBlockType)arg2;
 - (void)showTodayViewForExtensions:(id)arg1 pid:(int)arg2;
 - (id)serviceHubProcessControlChannel;
+- (id)makeServiceHubProcessControlChannelForLauncher:(unsigned long long)arg1;
 - (void)terminateWatchAppForCompanionIdentifier:(id)arg1 options:(id)arg2 completionSemaphore:(id)arg3;
 - (BOOL)_shouldAttemptToRetryWatchAppLaunchAttemptForLaunchError:(id)arg1;
 - (void)_attemptToLaunchWatchAppForCompanionIdentifier:(id)arg1 options:(id)arg2 completionblock:(CDUnknownBlockType)arg3 attempt:(unsigned long long)arg4;

--- a/PrivateHeaders/IDEiOSSupportCore/DVTAbstractiOSDevice.h
+++ b/PrivateHeaders/IDEiOSSupportCore/DVTAbstractiOSDevice.h
@@ -27,6 +27,7 @@
 + (id)nameForDeviceFamilyObject:(id)arg1;
 - (void)showTodayViewForExtensions:(id)arg1 pid:(int)arg2;
 - (id)serviceHubProcessControlChannel;
+- (id)makeServiceHubProcessControlChannelForLauncher:(unsigned long long)arg1;
 - (id)iconImage;
 - (id)deviceClassForDisplay;
 - (BOOL)supportsBuildingThinnedResources;


### PR DESCRIPTION
I create a complete [class-dump of Xcode](https://github.com/denis-panov/ClassDump-Xcode10.2) and found new header [makeServiceHubProcessControlChannelForLauncher](https://github.com/denis-panov/ClassDump-Xcode10.2/blob/4eb14de5b42de8c41ca4a266b57f18bc7ac20103/SharedFrameworks/DVTFoundation/DVTDevice.h#L149). 
I'm not sure what value does need for this method, so just send arg1 as 0.
