### PR TITLE
Support Xcode 11

### DIFF
--- a/FBControlCore/Configuration/FBControlCoreConfigurationVariants.h
+++ b/FBControlCore/Configuration/FBControlCoreConfigurationVariants.h
@@ -107,6 +107,7 @@ extern FBOSVersionName const FBOSVersionNameiOS_11_4;
 extern FBOSVersionName const FBOSVersionNameiOS_12_0;
 extern FBOSVersionName const FBOSVersionNameiOS_12_1;
 extern FBOSVersionName const FBOSVersionNameiOS_12_2;
+extern FBOSVersionName const FBOSVersionNameiOS_13_0;
 extern FBOSVersionName const FBOSVersionNametvOS_9_0;
 extern FBOSVersionName const FBOSVersionNametvOS_9_1;
 extern FBOSVersionName const FBOSVersionNametvOS_9_2;
@@ -120,6 +121,8 @@ extern FBOSVersionName const FBOSVersionNametvOS_11_3;
 extern FBOSVersionName const FBOSVersionNametvOS_11_4;
 extern FBOSVersionName const FBOSVersionNametvOS_12_0;
 extern FBOSVersionName const FBOSVersionNametvOS_12_1;
+extern FBOSVersionName const FBOSVersionNametvOS_12_2;
+extern FBOSVersionName const FBOSVersionNametvOS_13_0;
 extern FBOSVersionName const FBOSVersionNamewatchOS_2_0;
 extern FBOSVersionName const FBOSVersionNamewatchOS_2_1;
 extern FBOSVersionName const FBOSVersionNamewatchOS_2_2;
@@ -131,6 +134,8 @@ extern FBOSVersionName const FBOSVersionNamewatchOS_4_1;
 extern FBOSVersionName const FBOSVersionNamewatchOS_4_2;
 extern FBOSVersionName const FBOSVersionNamewatchOS_5_0;
 extern FBOSVersionName const FBOSVersionNamewatchOS_5_1;
+extern FBOSVersionName const FBOSVersionNamewatchOS_5_2;
+extern FBOSVersionName const FBOSVersionNamewatchOS_6_0;
 
 #pragma mark Devices
 

--- a/FBControlCore/Configuration/FBControlCoreConfigurationVariants.m
+++ b/FBControlCore/Configuration/FBControlCoreConfigurationVariants.m
@@ -85,6 +85,7 @@ FBOSVersionName const FBOSVersionNameiOS_11_4 = @"iOS 11.4";
 FBOSVersionName const FBOSVersionNameiOS_12_0 = @"iOS 12.0";
 FBOSVersionName const FBOSVersionNameiOS_12_1 = @"iOS 12.1";
 FBOSVersionName const FBOSVersionNameiOS_12_2 = @"iOS 12.2";
+FBOSVersionName const FBOSVersionNameiOS_13_0 = @"iOS 13.0";
 FBOSVersionName const FBOSVersionNametvOS_9_0 = @"tvOS 9.0";
 FBOSVersionName const FBOSVersionNametvOS_9_1 = @"tvOS 9.1";
 FBOSVersionName const FBOSVersionNametvOS_9_2 = @"tvOS 9.2";
@@ -98,6 +99,8 @@ FBOSVersionName const FBOSVersionNametvOS_11_3 = @"tvOS 11.3";
 FBOSVersionName const FBOSVersionNametvOS_11_4 = @"tvOS 11.4";
 FBOSVersionName const FBOSVersionNametvOS_12_0 = @"tvOS 12.0";
 FBOSVersionName const FBOSVersionNametvOS_12_1 = @"tvOS 12.1";
+FBOSVersionName const FBOSVersionNametvOS_12_2 = @"tvOS 12.2";
+FBOSVersionName const FBOSVersionNametvOS_13_0 = @"tvOS 13.0";
 FBOSVersionName const FBOSVersionNamewatchOS_2_0 = @"watchOS 2.0";
 FBOSVersionName const FBOSVersionNamewatchOS_2_1 = @"watchOS 2.1";
 FBOSVersionName const FBOSVersionNamewatchOS_2_2 = @"watchOS 2.2";
@@ -109,6 +112,8 @@ FBOSVersionName const FBOSVersionNamewatchOS_4_1 = @"watchOS 4.1";
 FBOSVersionName const FBOSVersionNamewatchOS_4_2 = @"watchOS 4.2";
 FBOSVersionName const FBOSVersionNamewatchOS_5_0 = @"watchOS 5.0";
 FBOSVersionName const FBOSVersionNamewatchOS_5_1 = @"watchOS 5.1";
+FBOSVersionName const FBOSVersionNamewatchOS_5_2 = @"watchOS 5.2";
+FBOSVersionName const FBOSVersionNamewatchOS_6_0 = @"watchOS 6.0";
 
 @implementation FBDeviceType
 
@@ -371,6 +376,7 @@ FBOSVersionName const FBOSVersionNamewatchOS_5_1 = @"watchOS 5.1";
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_12_0],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_12_1],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_12_2],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_13_0],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_0],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_1],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_2],
@@ -380,15 +386,25 @@ FBOSVersionName const FBOSVersionNamewatchOS_5_1 = @"watchOS 5.1";
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_11_0],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_11_1],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_11_2],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_11_3],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_11_4],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_12_0],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_12_1],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_12_2],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_13_0],
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_2_0],
-      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_2_1],
-      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_2_2],
-      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_3_0],
-      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_3_1],
-      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_3_2],
-      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_4_0],
-      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_4_1],
-      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_4_2],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_2_1],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_2_2],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_3_0],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_3_1],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_3_2],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_4_0],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_4_1],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_4_2],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_5_0],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_5_1],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_5_2],
+      [FBOSVersion watchOSWithName:FBOSVersionNamewatchOS_6_0],
     ];
   });
   return OSConfigurations;

--- a/FBDeviceControl/FBDeviceControl.xcconfig
+++ b/FBDeviceControl/FBDeviceControl.xcconfig
@@ -3,7 +3,7 @@
 #include "../Configuration/Framework.xcconfig"
 
 // Weak-Link Xcode Private Frameworks
-OTHER_LDFLAGS = $(inherited) -weak_framework DTXConnectionServices -weak_framework DVTFoundation -weak_framework IBAutolayoutFoundation -weak_framework IDEFoundation -weak_framework IDEKit -weak_library $(DEVELOPER_DIR)/../PlugIns/IDEiOSSupportCore.ideplugin/Contents/MacOS/IDEiOSSupportCore -weak_library $(DEVELOPER_DIR)/../PlugIns/IDESourceEditor.ideplugin/Contents/MacOS/IDESourceEditor
+OTHER_LDFLAGS = $(inherited) -weak_framework DTXConnectionServices -weak_framework DVTFoundation -weak_framework IBAutolayoutFoundation -weak_framework IDEFoundation -weak_framework IDEKit -weak_library $(DEVELOPER_DIR)/../PlugIns/IDEiOSSupportCore.ideplugin/Contents/MacOS/IDEiOSSupportCore
 
 // Target-Specific Settings
 INFOPLIST_FILE = $(SRCROOT)/FBDeviceControl/FBDeviceControl-Info.plist

--- a/FBSimulatorControl/HID/FBSimulatorIndigoHID.m
+++ b/FBSimulatorControl/HID/FBSimulatorIndigoHID.m
@@ -215,7 +215,7 @@ IndigoMessage *(*IndigoHIDMessageForMouseNSEvent)(CGPoint *point0, CGPoint *poin
 
 + (IndigoMessage *)keyboardMessageWithDirection:(FBSimulatorHIDDirection)direction keyCode:(unsigned int)keycode messageSizeOut:(size_t *)messageSizeOut
 {
-  IndigoMessage *message = IndigoHIDMessageForKeyboardArbitrary((int) keycode, direction);
+  IndigoMessage *message = IndigoHIDMessageForKeyboardArbitrary((int)keycode, (int)direction);
   if (messageSizeOut) {
     *messageSizeOut = malloc_size(message);
   }
@@ -224,9 +224,9 @@ IndigoMessage *(*IndigoHIDMessageForMouseNSEvent)(CGPoint *point0, CGPoint *poin
 
 + (IndigoMessage *)buttonMessageWithDirection:(FBSimulatorHIDDirection)direction button:(FBSimulatorHIDButton)button messageSizeOut:(size_t *)messageSizeOut
 {
-  IndigoMessage *message = IndigoHIDMessageForButton((int) [self eventSourceForButton:button], direction, ButtonEventTargetHardware);
+  IndigoMessage *message = IndigoHIDMessageForButton((int) [self eventSourceForButton:button], (int)direction, ButtonEventTargetHardware);
   if (messageSizeOut) {
-    *messageSizeOut = malloc_size(message);
+      *messageSizeOut = malloc_size(message);
   }
   return message;
 }

--- a/FBSimulatorControl/HID/FBSimulatorIndigoHID.m
+++ b/FBSimulatorControl/HID/FBSimulatorIndigoHID.m
@@ -226,7 +226,7 @@ IndigoMessage *(*IndigoHIDMessageForMouseNSEvent)(CGPoint *point0, CGPoint *poin
 {
   IndigoMessage *message = IndigoHIDMessageForButton((int) [self eventSourceForButton:button], (int)direction, ButtonEventTargetHardware);
   if (messageSizeOut) {
-      *messageSizeOut = malloc_size(message);
+    *messageSizeOut = malloc_size(message);
   }
   return message;
 }

--- a/FBSimulatorControl/Notifiers/FBCoreSimulatorNotifier.m
+++ b/FBSimulatorControl/Notifiers/FBCoreSimulatorNotifier.m
@@ -21,7 +21,7 @@ FBTerminationHandleType const FBTerminationHandleTypeCoreSimulatorNotifier = @"C
 
 @interface FBCoreSimulatorNotifier ()
 
-@property (nonatomic, readonly, assign) unsigned long long handle;
+@property (nonatomic, readonly, assign) NSUInteger handle;
 @property (nonatomic, readonly, strong) id notifier;
 
 @end
@@ -30,17 +30,17 @@ FBTerminationHandleType const FBTerminationHandleTypeCoreSimulatorNotifier = @"C
 
 + (instancetype)notifierForSimDevice:(SimDevice *)simDevice queue:(dispatch_queue_t)queue block:(void (^)(NSDictionary *info))block
 {
-  id<SimDeviceNotifier> notifier = simDevice.notificationManager;
+  id<NSObject, SimDeviceNotifier> notifier = simDevice.notificationManager;
   return [[self alloc] initWithNotifier:notifier queue:queue block:block];
 }
 
 + (instancetype)notifierForSet:(FBSimulatorSet *)set queue:(dispatch_queue_t)queue block:(void (^)(NSDictionary *info))block
 {
-  id<SimDeviceNotifier> notifier = set.deviceSet.notificationManager;
+  id<NSObject, SimDeviceNotifier> notifier = set.deviceSet.notificationManager;
   return [[self alloc] initWithNotifier:notifier queue:queue block:block];
 }
 
-- (instancetype)initWithNotifier:(id<SimDeviceNotifier>)notifier queue:(dispatch_queue_t)queue block:(void (^)(NSDictionary *info))block
+- (instancetype)initWithNotifier:(id<NSObject, SimDeviceNotifier>)notifier queue:(dispatch_queue_t)queue block:(void (^)(NSDictionary *info))block
 {
   self = [super init];
   if (!self) {
@@ -48,13 +48,22 @@ FBTerminationHandleType const FBTerminationHandleTypeCoreSimulatorNotifier = @"C
   }
 
   _notifier = notifier;
-  _handle = [notifier registerNotificationHandler:^(NSDictionary *info) {
-    dispatch_async(queue, ^{
-      block(info);
-    });
-  }];
+  _handle = [FBCoreSimulatorNotifier registerNotificationHandler:notifier queue:queue handler:block];
 
   return self;
+}
+
++ (NSUInteger)registerNotificationHandler:(id<NSObject, SimDeviceNotifier>)notifier queue:(dispatch_queue_t)queue handler:(void (^)(NSDictionary *))handler
+{
+    if ([notifier respondsToSelector:@selector(registerNotificationHandlerOnQueue:handler:)]) {
+        return [notifier registerNotificationHandlerOnQueue:queue handler:handler];
+    } else {
+        return [notifier registerNotificationHandler:^(NSDictionary *info) {
+            dispatch_async(queue, ^{
+                handler(info);
+            });
+        }];
+    }
 }
 
 - (void)terminate

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorLaunchTests.m
@@ -74,7 +74,7 @@
 
 - (void)testLaunchesTV
 {
-  [self testLaunchesSingleSimulator:[FBSimulatorConfiguration withDeviceModel:FBDeviceModelAppleTV1080p]];
+  [self testLaunchesSingleSimulator:[FBSimulatorConfiguration withDeviceModel:FBDeviceModelAppleTV4KAt1080p]];
 }
 
 - (void)testLaunchesPreviousiOSVersionAndAwaitsServices

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorSetTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorSetTests.m
@@ -100,4 +100,18 @@
   }
 }
 
+- (void)testCanFetchAllAvailableSimulators
+{
+    // invoke FBSImulatorControl the same way as iOSDeviceManager does
+    FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
+                                                      configurationWithDeviceSetPath:nil
+                                                      options:FBSimulatorManagementOptionsIgnoreSpuriousKillFail];
+    
+    NSError *err;
+    FBSimulatorControl *simControl = [FBSimulatorControl withConfiguration:configuration error:&err];
+    XCTAssertNil(err);
+    NSArray<FBSimulator *> *availableSimulators = [[simControl set] allSimulators];
+    XCTAssertNotNil(availableSimulators);
+}
+
 @end

--- a/FBSimulatorControlTests/Tests/Unit/FBSimulatorConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/Unit/FBSimulatorConfigurationTests.m
@@ -56,8 +56,8 @@
 
 - (void)testTVOSConfiguration
 {
-  FBSimulatorConfiguration *configuration = [[FBSimulatorConfiguration withDeviceModel:FBDeviceModelAppleTV1080p] withOSNamed:FBOSVersionNametvOS_10_0];
-  XCTAssertEqualObjects(configuration.device.model, FBDeviceModelAppleTV1080p);
+  FBSimulatorConfiguration *configuration = [[FBSimulatorConfiguration withDeviceModel:FBDeviceModelAppleTV4KAt1080p] withOSNamed:FBOSVersionNametvOS_10_0];
+  XCTAssertEqualObjects(configuration.device.model, FBDeviceModelAppleTV4KAt1080p);
   XCTAssertEqualObjects(configuration.os.name, FBOSVersionNametvOS_10_0);
 }
 

--- a/PrivateHeaders/CoreSimulator/SimDeviceNotifier-Protocol.h
+++ b/PrivateHeaders/CoreSimulator/SimDeviceNotifier-Protocol.h
@@ -7,12 +7,15 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@class NSObject;
-@protocol OS_dispatch_queue;
+#import <Foundation/Foundation.h>
 
 @protocol SimDeviceNotifier
 - (BOOL)unregisterNotificationHandler:(unsigned long long)arg1 error:(id *)arg2;
-- (unsigned long long)registerNotificationHandler:(void (^)(NSDictionary *))arg2;
 - (unsigned long long)registerNotificationHandlerOnQueue:(NSObject<OS_dispatch_queue> *)arg1 handler:(void (^)(NSDictionary *))arg2;
+
+// Removed in Xcode 11.0
+@optional;
+- (unsigned long long)registerNotificationHandler:(void (^)(NSDictionary *))arg1;
+
 @end
 


### PR DESCRIPTION
1) Add missed iOS, tvOS, watchOS
2) Fix `tvOSWithName` to `watchOSWithName`
3) Fix compilation issue with Xcode 11 - add type casting for `direction`
4) Remove weak_library `IDESourceEditor`