### PR TITLE
Xcode 12.4 support

### DIFF
--- a/FBControlCore/Configuration/FBControlCoreConfigurationVariants.h
+++ b/FBControlCore/Configuration/FBControlCoreConfigurationVariants.h
@@ -144,6 +144,8 @@ extern FBOSVersionName const FBOSVersionNameiOS_13_7;
 extern FBOSVersionName const FBOSVersionNameiOS_14_0;
 extern FBOSVersionName const FBOSVersionNameiOS_14_1;
 extern FBOSVersionName const FBOSVersionNameiOS_14_2;
+extern FBOSVersionName const FBOSVersionNameiOS_14_3;
+extern FBOSVersionName const FBOSVersionNameiOS_14_4;
 extern FBOSVersionName const FBOSVersionNametvOS_9_0;
 extern FBOSVersionName const FBOSVersionNametvOS_9_1;
 extern FBOSVersionName const FBOSVersionNametvOS_9_2;

--- a/FBControlCore/Configuration/FBControlCoreConfigurationVariants.m
+++ b/FBControlCore/Configuration/FBControlCoreConfigurationVariants.m
@@ -120,6 +120,8 @@ FBOSVersionName const FBOSVersionNameiOS_13_7 = @"iOS 13.7";
 FBOSVersionName const FBOSVersionNameiOS_14_0 = @"iOS 14.0";
 FBOSVersionName const FBOSVersionNameiOS_14_1 = @"iOS 14.1";
 FBOSVersionName const FBOSVersionNameiOS_14_2 = @"iOS 14.2";
+FBOSVersionName const FBOSVersionNameiOS_14_3 = @"iOS 14.3";
+FBOSVersionName const FBOSVersionNameiOS_14_4 = @"iOS 14.4";
 FBOSVersionName const FBOSVersionNametvOS_9_0 = @"tvOS 9.0";
 FBOSVersionName const FBOSVersionNametvOS_9_1 = @"tvOS 9.1";
 FBOSVersionName const FBOSVersionNametvOS_9_2 = @"tvOS 9.2";
@@ -454,6 +456,8 @@ FBOSVersionName const FBOSVersionNamewatchOS_7_0 = @"watchOS 7.0";
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_0],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_1],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_2],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_3],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_4],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_0],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_1],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_2],

--- a/FBControlCore/Processes/FBProcessFetcher.m
+++ b/FBControlCore/Processes/FBProcessFetcher.m
@@ -166,6 +166,17 @@ static BOOL ProcessNameForProcessIdentifier(pid_t processIdentifier, char *buffe
 
 #pragma mark Lifecycle
 
+static size_t MaxArgumentBufferSize = ARG_MAX; // A temporary value that is filled on load.
+static size_t const MaxPidBufferSize = 5568 * 2 * sizeof(int); // From 'ulimit -u', but twice as large, in ints.
+
++ (void)load
+{
+  int name[2] = {CTL_KERN, KERN_ARGMAX};
+  size_t size = sizeof(MaxArgumentBufferSize);
+  int status = sysctl(name, 2, &MaxArgumentBufferSize, &size, NULL, 0);
+  NSAssert(status != -1, @"Failed to get the KERN_ARGMAX from sysctl %s", strerror(errno));
+}
+
 - (instancetype)init
 {
   self = [super init];
@@ -173,10 +184,10 @@ static BOOL ProcessNameForProcessIdentifier(pid_t processIdentifier, char *buffe
     return nil;
   }
 
-  _argumentBufferSize = sizeof(char) * ARG_MAX;
+  _argumentBufferSize = MaxArgumentBufferSize;
   _argumentBuffer = malloc(_argumentBufferSize);
 
-  _pidBufferSize = sizeof(pid_t) * PID_MAX;
+  _pidBufferSize = MaxPidBufferSize;
   _pidBuffer = malloc(_pidBufferSize);
 
   return self;

--- a/bin/make/frameworks.sh
+++ b/bin/make/frameworks.sh
@@ -39,6 +39,9 @@ function framework_build() {
     DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
     ENABLE_TESTABILITY=NO \
     GCC_OPTIMIZATION_LEVEL=0 \
+    ARCHS="x86_64" \
+    VALID_ARCHS="x86_64" \
+    MACOSX_DEPLOYMENT_TARGET="10.10" \
     -SYMROOT="${BUILD_DIR}" \
     -OBJROOT="${BUILD_DIR}" \
     -project "${XC_PROJECT}" \


### PR DESCRIPTION
- Applied fix for maximum argument buffer sizes in FBProcessFetcher.
- Added ARCHS fix in 'make frameworks' for building frameworks only for x86_64.